### PR TITLE
use __GNUC_MINOR__ instead of __GNUC__MINOR__

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -33,7 +33,7 @@
 	#endif
 #else
 	#ifndef __GNUC_PREREQ
-    	#define __GNUC_PREREQ(major, minor) ((((__GNUC__) << 16) + (__GNUC__MINOR__)) >= (((major) << 16) + (minor)))
+    	#define __GNUC_PREREQ(major, minor) ((((__GNUC__) << 16) + (__GNUC_MINOR__)) >= (((major) << 16) + (minor)))
 	#endif
 	#if __GNUC_PREREQ(4, 3) && !defined(__APPLE__)
 		#include <cpuid.h>


### PR DESCRIPTION
The macro must contain five instead of six underscores, more details can be found here:
http://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html

This patch fixes e.g. the compilation of xbyak using systems without predefined __GNUC_PREREQ.
