### PR TITLE
Fixes for detection of <unordered_map> vs. <tr1/unordered_map>, 64-bit Darwin.

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -3,12 +3,23 @@ XBYAK_INC=../xbyak/xbyak.h
 
 BOOST_EXIST=$(shell echo "\#include <boost/spirit/core.hpp>" | (gcc -E - 2>/dev/null) | grep "boost/spirit/core.hpp" >/dev/null && echo "1")
 
-BIT=32
-ifeq ($(shell uname -m),x86_64)
-BIT=64
-endif
 ifeq ($(shell uname -s),Darwin)
-BIT=64
+	ifeq ($(shell uname -m),x86_64)
+		BIT=64
+	endif
+	ifeq ($(shell uname -m),i386)
+		BIT=32
+	endif
+	ifeq ($(shell sw_vers -productVersion | cut -c1-4 | sed 's/\.//'),105)
+		ifeq ($(shell sysctl -n hw.cpu64bit_capable),1)
+			BIT=64
+		endif
+	endif
+else
+	BIT=32
+	ifeq ($(shell uname -m),x86_64)
+		BIT=64
+	endif
 endif
 
 ifeq ($(BIT),64)

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -20,16 +20,27 @@
 #include <list>
 #include <string>
 #include <algorithm>
-#if (__cplusplus >= 201103) || (_MSC_VER >= 1500) || defined(__GXX_EXPERIMENTAL_CXX0X__)
+
+// This covers -std=(gnu|c)++(0x|11|1y), -stdlib=libc++, and modern Microsoft.
+#if ((defined(_MSC_VER) && (_MSC_VER >= 1600)) || defined(_LIBCPP_VERSION) ||\
+	 			 ((__cplusplus >= 201103) || defined(__GXX_EXPERIMENTAL_CXX0X__)))
 	#include <unordered_map>
-	#if defined(_MSC_VER) && (_MSC_VER < 1600)
-		#define XBYAK_USE_TR1_UNORDERED_MAP
-	#else
-		#define XBYAK_USE_UNORDERED_MAP
-	#endif
-#elif (__GNUC__ >= 4 && __GNUC_MINOR__ >= 5) || (__clang_major__ >= 3)
+	#define XBYAK_USE_UNORDERED_MAP
+
+// Clang/llvm-gcc and ICC-EDG in 'GCC-mode' always claim to be GCC 4.2, using
+// libstdcxx 20070719 (from GCC 4.2.1, the last GPL 2 version).
+// These headers have been expanded/fixed in various forks.
+// In F.S.F. 'real' GCC, issues with the tr headers were resolved in GCC 4.5.
+#elif defined(__GNUC__) && (__GNUC__ >= 4) && ((__GNUC_MINOR__ >= 5) || \
+								 ((__GLIBCXX__ >= 20070719) && (__GNUC_MINOR__ >= 2) && \
+									(defined(__INTEL_COMPILER) || defined(__llvm__))))
 	#include <tr1/unordered_map>
 	#define XBYAK_USE_TR1_UNORDERED_MAP
+
+#elif defined(_MSC_VER) && (_MSC_VER >= 1500) && (_MSC_VER < 1600)
+	#include <unordered_map>
+	#define XBYAK_USE_TR1_UNORDERED_MAP
+
 #else
 	#include <map>
 #endif


### PR DESCRIPTION
Hello! This is so cool looking, I can't wait to try it out! But I ran into an immediate little problem though, the defines you were testing to determine whether to use `<tr1/unordered_map>` vs. `<unordered_map>` were wrong on my machine, and when I looked at it I saw there were a few other cases that it would be returning the incorrect header, especially on Darwin. Let me know if for some reason you think this is wrong, but I'm pretty confident that it now covers the various cases correctly.

Also, I saw in the samples makefile how you were trying to correctly detect 32- or 64-bit on Darwin, which can be very tricky, because some versions of Mac OS X which are in fact fully cabable of running 64-bit binaries run a 32-bit kernel and Unix subsystem. So I went ahead and covered up the gaps there, if thats ok!

  :)

~Geoff
