### PR TITLE
Fix building with Mingw32, mmap isn't available on windows

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -25,7 +25,7 @@
 #endif
 
 //#define XBYAK_USE_MMAP_ALLOCATOR
-#ifndef __GNUC__
+#if defined __GNUC__ && !(defined __MINGW32__)
 	#undef XBYAK_USE_MMAP_ALLOCATOR
 #endif
 
@@ -283,7 +283,7 @@ struct Allocator {
 	virtual bool useProtect() const { return true; }
 };
 
-#ifdef __GNUC__
+#if defined __GNUC__ && !(defined __MINGW32__)
 class MmapAllocator : Allocator {
 	typedef XBYAK_STD_UNORDERED_MAP<uintptr_t, size_t> SizeList;
 	SizeList sizeList_;
@@ -640,7 +640,7 @@ class CodeArray {
 	AddrInfoList addrInfoList_;
 	const Type type_;
 #ifdef XBYAK_USE_MMAP_ALLOCATOR
-	MmapAllocator defaultAllocator_;
+    MmapAllocator defaultAllocator_;
 #else
 	Allocator defaultAllocator_;
 #endif


### PR DESCRIPTION
HEAD version doesn't compile with Mingw32, error message:

In file included from ..\jittest\main.cpp:3:0:
..\jittest\xbyak/xbyak.h:300:4: error: #error "not supported"
   #error "not supported"
    ^
..\jittest\xbyak/xbyak.h: In member function 'virtual Xbyak::uint8* Xbyak::MmapAllocator::alloc(size_t)':
..\jittest\xbyak/xbyak.h:302:30: error: 'PROT_READ' was not declared in this scope
   void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
                              ^
..\jittest\xbyak/xbyak.h:302:42: error: 'PROT_WRITE' was not declared in this scope
   void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
                                          ^
..\jittest\xbyak/xbyak.h:302:54: error: 'mode' was not declared in this scope
   void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
                                                      ^
..\jittest\xbyak/xbyak.h:302:65: error: 'mmap' was not declared in this scope
   void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
                                                                 ^
..\jittest\xbyak/xbyak.h:303:12: error: 'MAP_FAILED' was not declared in this scope
   if (p == MAP_FAILED) throw Error(ERR_CANT_ALLOC);
            ^
..\jittest\xbyak/xbyak.h: In member function 'virtual void Xbyak::MmapAllocator::free(Xbyak::uint8*)':
..\jittest\xbyak/xbyak.h:313:40: error: 'munmap' was not declared in this scope
   if (munmap((void*)i->first, i->second) < 0) throw Error(ERR_MUNMAP);
                                        ^