### PR TITLE
clear clabel definition lists in LabelManager::reset

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1116,6 +1116,8 @@ public:
 		stateList_.clear();
 		stateList_.push_back(SlabelState());
 		stateList_.push_back(SlabelState());
+		clabelDefList_.clear();
+		clabelUndefList_.clear();
 	}
 	void enterLocal()
 	{


### PR DESCRIPTION
While slabels are being cleared in `LabelManager::reset`, clabel definition lists were not.