### PR TITLE
Only protect if buffer is internally allocated

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -705,7 +705,7 @@ protected:
 			uint64 disp = i->getVal(top_);
 			rewrite(i->codeOffset, disp, i->jmpSize);
 		}
-		if (alloc_->useProtect() && !protect(top_, size_, true)) throw Error(ERR_CANT_PROTECT);
+		if (isAutoGrow() && alloc_->useProtect() && !protect(top_, size_, true)) throw Error(ERR_CANT_PROTECT);
 	}
 public:
 	explicit CodeArray(size_t maxSize, void *userPtr = 0, Allocator *allocator = 0)
@@ -2178,7 +2178,7 @@ public:
 	}
 	bool hasUndefinedLabel() const { return labelMgr_.hasUndefSlabel() || labelMgr_.hasUndefClabel(); }
 	/*
-		call ready() to complete generating code on AutoGrow
+		call ready() to complete generating code
 	*/
 	void ready()
 	{


### PR DESCRIPTION
Constructor didn't protect for AUTO_GROW
calcJmpAddress protected even if USER_BUF (inconsistent with the rest of the protect behavior)

Not exactly sure if this is a bug in calcJmpAddress or not. In my case I allcoate a pre-protected, big buffer and calling protect was a huge performance issue. Thish will break existing code that allocates the buffer manually but depends on xbyak changing protection. 

For auto alloc modes, changing the protection both in the constructor and in ready() seems a bit excessive -- isn't only one of them needed?