### PR TITLE
CodeGenerator::resetSize() doesn't reset isCalledCalcJmpAddress_

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -841,6 +841,7 @@ public:
 	{
 		size_ = 0;
 		addrInfoList_.clear();
+		isCalledCalcJmpAddress_ = false;
 	}
 	void db(int code)
 	{


### PR DESCRIPTION
Currently `CodeGenerator::resetSize()` doesn't reset `isCalledCalcJmpAddress_` to false, so if you call `CodeGenerator::reset()`, further calls to `CodeGenerator::ready()` will not resolve jmp offsets.

I'm not sure if it's appropriate to make this change to `CodeGenerator::resetSize()` or if it should be done to `CodeGenerator::reset()`, I went with the former.