### PR TITLE
intel icc 17.0.4 compatibility

### DIFF
--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -1,3 +1,7 @@
+#ifdef jnl
+# undef jnl
+#endif
+
 const char *getVersionString() const { return "5.43"; }
 void adc(const Operand& op, uint32 imm) { opRM_I(op, imm, 0x10, 2); }
 void adc(const Operand& op1, const Operand& op2) { opRM_RM(op1, op2, 0x10); }


### PR DESCRIPTION
Xbyak do use overloads of standard function name called jnl :
https://www.gnu.org/software/libc/manual/html_node/Special-Functions.html

According to libc documentation it is a function, but all functions defined in those special functions section can be a macro too: https://ftp.gnu.org/old-gnu/Manuals/glibc-2.2.3/html_chapter/libc_1.html#SEC11
depending on implementation. xbyak however uses overload of standard Bessel jnl function when compiled with gcc, however Intel icc compiler use macro for jnl instead of function

Here is a fix to became 17.0.4.210 icc friendly.
Issue is mostly windows specific since on linux math.h can be included after xbyak.h, while on windows, xbyak.h includes windows.h before xbyak_mnemonic.h  that does internally includes math.h and problem appeared as : 

xbyak/xbyak_mnemonic.h(420): error : expected a type specifier
    void jnl(const Label& label, LabelType type = T_AUTO) { opJmp(label, type, 0x7D, 0x8D, 0x0F); }