### PR TITLE
Change default value for n_cores in setCacheHierarchy.

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -96,7 +96,7 @@ class Cpu {
 //		const unsigned int INSTRUCTION_CACHE = 2;
 		const unsigned int UNIFIED_CACHE = 3;
 		unsigned int smt_width = 0;
-		unsigned int n_cores = 0;
+		unsigned int n_cores = (unsigned int) -1;
 		unsigned int data[4];
 
 		/*


### PR DESCRIPTION
If the default value is 0 and the cpu has no leaf B, then in the loop
on the subleaves of leaf 4, the number of cores sharing a data cache will be 0.