### PR TITLE
Fixes an error raised by clang < 3.9

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -566,7 +566,7 @@ struct EvexModifierRounding {
 	explicit EvexModifierRounding(int rounding) : rounding(rounding) {}
 	int rounding;
 };
-struct EvexModifierZero{};
+struct EvexModifierZero{EvexModifierZero() {}};
 
 struct Xmm : public Mmx {
 	explicit Xmm(int idx = 0, Kind kind = Operand::XMM, int bit = 128) : Mmx(idx, kind, bit) { }


### PR DESCRIPTION
Sorry I did not catch this earlier.
clang prior the 3.9 version requires a user-provided default constructor to be const-default-constructible.
https://stackoverflow.com/questions/7411515/why-does-c-require-a-user-provided-default-constructor-to-default-construct-a