### PR TITLE
Prevent cores_sharing_data_cache being zero on Intel Xeon E5 v2

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -138,6 +138,7 @@ class Cpu {
 					* (extractBit(data[1], 0, 11) + 1)
 					* (data[2] + 1);
 				if (cacheType == DATA_CACHE && smt_width == 0) smt_width = nb_logical_cores;
+				smt_width = (std::min)(smt_width, nb_logical_cores);
 				assert(smt_width != 0);
 				cores_sharing_data_cache[data_cache_levels] = nb_logical_cores / smt_width;
 				data_cache_levels++;


### PR DESCRIPTION
I have trouble on amazon ec2 r3.large instance with the Intel(R) Xeon(R) CPU E5-2680 v2 processor:
`smt_width` was 2 while `nb_logical_cores` was 1, so `cores_sharing_data_cache[data_cache_levels]` was zero which cause SIGFPE later. Here is workaround