### PR TITLE
specify MAP_JIT mmap flag on macOS

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -336,7 +336,9 @@ public:
 	{
 		const size_t alignedSizeM1 = inner::ALIGN_PAGE_SIZE - 1;
 		size = (size + alignedSizeM1) & ~alignedSizeM1;
-#ifdef MAP_ANONYMOUS
+#if defined(__APPLE__) && defined(MAP_JIT)
+		const int mode = MAP_PRIVATE | MAP_ANONYMOUS | MAP_JIT;
+#elif defined(MAP_ANONYMOUS)
 		const int mode = MAP_PRIVATE | MAP_ANONYMOUS;
 #elif defined(MAP_ANON)
 		const int mode = MAP_PRIVATE | MAP_ANON;


### PR DESCRIPTION
Hi Herumi,

This change reduces the hardened ruhtime entitlements required by the JIT-ed code on macOS down to [com.apple.security.cs.allow-jit](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-jit) by specifying the `MAP_JIT` flag to `mmap()`.