### PR TITLE
Fix segmentation fault in calc sample

### DIFF
--- a/sample/calc.cpp
+++ b/sample/calc.cpp
@@ -155,9 +155,9 @@ struct Grammar : public boost::spirit::classic::grammar<Grammar> {
 
 void put(const std::vector<double>& x)
 {
-	printf("%f", x[0]);
-	for (size_t i = 1, n = x.size(); i < n; i++) {
-		printf(", %f", x[i]);
+	for (size_t i = 0, n = x.size(); i < n; i++) {
+		if (i > 0) printf(", ");
+		printf("%f", x[i]);
 	}
 }
 


### PR DESCRIPTION
Segmentation fault occurred in `calc` sample
when no variables are given from command line argument:

```
$ cd sample
$ make calc64
$ ./calc64 "" "123"
varTbl = { }
64bit mode
zsh: segmentation fault  ./calc64 "" "123"
```

`put` function always access `x[0]`,
but segmentation fault occurred when `x.size() == 0`.