### PR TITLE
Remove #include <winsock2.h>

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -72,7 +72,6 @@
 	#define XBYAK_STD_UNORDERED_MULTIMAP std::multimap
 #endif
 #ifdef _WIN32
-	#include <winsock2.h>
 	#include <windows.h>
 	#include <malloc.h>
 	#define XBYAK_TLS __declspec(thread)


### PR DESCRIPTION
`winsock2.h` is a very noisy inclusion and not necessary as far as I can tell for using xbyak on Windows. It makes including `xbyak.h` order dependent because it must be included prior to `Windows.h` otherwise compilation explodes. 