### PR TITLE
Use thread_local for XBYAK_TLS when supported

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -109,6 +109,8 @@
 #endif
 
 #if (__cplusplus >= 201103) || (_MSC_VER >= 1800)
+	#undef XBYAK_TLS
+	#define XBYAK_TLS thread_local
 	#define XBYAK_VARIADIC_TEMPLATE
 #endif
 


### PR DESCRIPTION
Some compilers may not support __declspec(thread) but they can build apps using >= C++11 by default.