### PR TITLE
fix mov interface

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -2507,15 +2507,12 @@ public:
 			XBYAK_THROW(ERR_BAD_COMBINATION)
 		}
 	}
-	void mov(const NativeReg& reg, const char *label) // can't use std::string
-	{
-		if (label == 0) {
-			mov(static_cast<const Operand&>(reg), 0); // call imm
-			return;
-		}
-		mov_imm(reg, dummyAddr);
-		putL(label);
-	}
+
+	// The template is used to avoid ambiguity when the 2nd argument is 0.
+	// When the 2nd argument is 0 the call goes to
+	// `void mov(const Operand& op, uint64 imm)`.
+	template <typename T1, typename T2>
+	void mov(const T1& reg, const T2 *label) { T1::unexpected; }
 	void mov(const NativeReg& reg, const Label& label)
 	{
 		mov_imm(reg, dummyAddr);
@@ -2734,6 +2731,14 @@ public:
 	}
 #endif
 };
+
+template <>
+inline void CodeGenerator::mov(const NativeReg& reg, const char *label) // can't use std::string
+{
+	assert(label);
+	mov_imm(reg, dummyAddr);
+	putL(label);
+}
 
 namespace util {
 static const Mmx mm0(0), mm1(1), mm2(2), mm3(3), mm4(4), mm5(5), mm6(6), mm7(7);


### PR DESCRIPTION
Make mov interface that takes a pointer template to avoid ambiguity when
the 2nd argument is 0UL. Now, when the 2nd argument is 0 or 0UL the call
goes to the correct version of the mov method.