### PR TITLE
make Xbyak::local::l_err inline with block scope static TLS l_error

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -267,13 +267,23 @@ inline const char *ConvertErrorToString(int err)
 #ifdef XBYAK_NO_EXCEPTION
 namespace local {
 
-static XBYAK_TLS int l_err = 0;
-inline void SetError(int err) { if (err) l_err = err; } // keep the first err code
-
+inline int &l_err() {
+    static XBYAK_TLS int l_error;
+    return l_error;
+}
+inline void SetError(int err) {
+    if (err) { // keep the first err code
+        int &l_error = local::l_err();
+        l_error = err;
+    }
+}
 } // local
 
-inline void ClearError() { local::l_err = 0; }
-inline int GetError() { return local::l_err; }
+inline void ClearError() {
+    int &l_error = local::l_err();
+    l_error = 0;
+}
+inline int GetError() { return local::l_err(); }
 
 #define XBYAK_THROW(err) { local::SetError(err); return; }
 #define XBYAK_THROW_RET(err, r) { local::SetError(err); return r; }


### PR DESCRIPTION
This PR updates the exception-less error handling by (i) having a static TLS `l_error` in the scope of `int l_err()` function, and (ii) making this function `inline` which ensures that there will be only one definition of the function in a project. Ultimately, instead of having one `l_err` per object file, this PR enables having one `l_err` for an entire project.