### PR TITLE
fixed incorrect detection of AVX-512 on macOS

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -442,7 +442,11 @@ public:
 			if ((bv & 6) == 6) {
 				if (ECX & (1U << 28)) type_ |= tAVX;
 				if (ECX & (1U << 12)) type_ |= tFMA;
-				if (((bv >> 5) & 7) == 7) {
+				// do *not* check AVX-512 state on macOS because it has on-demand AVX-512 support
+			#if !defined(__APPLE__)
+				if (((bv >> 5) & 7) == 7)
+			#endif
+				{
 					getCpuidEx(7, 0, data);
 					if (EBX & (1U << 16)) type_ |= tAVX512F;
 					if (type_ & tAVX512F) {


### PR DESCRIPTION
AVX-512 support is rather unusual on macOS: it's on-demand, which means that AVX-512 is masked off in XCR0 by default even if it is actually supported. XCR0 should not be checked for AVX-512 support on macOS. Xbyak does this and thus always reports that AVX-512 is not supported. See more details here: https://github.com/apple/darwin-xnu/blob/0a798f6738bc1db01281fc08ae024145e84df927/osfmk/i386/fpu.c#L176