### PR TITLE
workaround g++5 issue with constexpr functions

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -874,7 +874,13 @@ public:
 	const Reg& getIndex() const { return index_; }
 	int getScale() const { return scale_; }
 	size_t getDisp() const { return disp_; }
-	XBYAK_CONSTEXPR void verify() const
+
+#if (__cplusplus >= 201402L) && !defined(__clang__) && defined(__GNUC__) && __GNUC__ <= 5
+	// workaround g++<=5 issue with c++14: "calling to non-constexpr function from constexpr function"
+#else
+	XBYAK_CONSTEXPR
+#endif
+	void verify() const
 	{
 		if (base_.getBit() >= 128) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
 		if (index_.getBit() && index_.getBit() <= 64) {


### PR DESCRIPTION
It seems gcc didn't fully implement C++14 relaxed requirements on constexpr functions, at least until version 6. 

Currently, if one tries to use Xbyak with g++ and `-std=c++14` or `-std=gnu++14` they most likely get one of those error:
``` bash
$ echo '#include <xbyak/xbyak.h>' | g++-5 -c -I. -std=c++14 -xc++ -
```
``` cpp
In file included from <stdin>:1:0:
./xbyak/xbyak.h: In member function ‘constexpr void Xbyak::RegExp::verify() const’:
./xbyak/xbyak.h:316:43: error: expression ‘<throw-expression>’ is not a constant-expression
 #define XBYAK_THROW(err) { throw Error(err); }
                                           ^
./xbyak/xbyak.h:879:30: note: in expansion of macro ‘XBYAK_THROW’
   if (base_.getBit() >= 128) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
                              ^
```
or
``` bash
$ echo '#include <xbyak/xbyak.h>' | g++-5 -DXBYAK_NO_EXCEPTION -c -I. -std=c++14 -xc++ -
```
``` cpp
In file included from <stdin>:1:0:
./xbyak/xbyak.h: In member function ‘constexpr void Xbyak::RegExp::verify() const’:
./xbyak/xbyak.h:287:43: error: call to non-constexpr function ‘void Xbyak::local::SetError(int)’
 #define XBYAK_THROW(err) { local::SetError(err); return; }
                                           ^
./xbyak/xbyak.h:879:30: note: in expansion of macro ‘XBYAK_THROW’
   if (base_.getBit() >= 128) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
                              ^
```

The patch workarounds this problem. I tried to find the corresponding issue in GCC bug-tracker, but failed.

It is also interesting that no other function is affected, except for `RegExp::verify()`...