### PR TITLE
fix cmake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.6...3.0.2)
 
-project(xbyak CXX)
+project(xbyak LANGUAGES CXX VERSION 5.994)
 
 file(GLOB headers xbyak/*.h)
 
@@ -18,17 +18,26 @@ if (DEFINED CMAKE_VERSION AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.2)
 	install(
 		TARGETS ${PROJECT_NAME}
 		EXPORT ${PROJECT_NAME}-targets
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 	)
 
-	configure_file(
+	include(CMakePackageConfigHelpers)
+	configure_package_config_file(
 		cmake/config.cmake.in
-		${PROJECT_NAME}Config.cmake
-		@ONLY
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+		INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+	)
+	write_basic_package_version_file(
+		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+		COMPATIBILITY SameMajorVersion
 	)
 
 	install(
-		FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+		FILES
+			"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+			"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+		DESTINATION
+			${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 	)
 
 	install(

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,1 +1,3 @@
+@PACKAGE_INIT@
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")


### PR DESCRIPTION
`configure_file` has been superseded by `configure_package_config_file`.
 Also add the `config-version.cmake` file, allowing to do:

```
find_package(xbyak 5.994 REQUIRED)
target_link_libraries(project PRIVATE xbyak::xbyak)
```