### PR TITLE
fix condition to throw error for invalid displacements

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1786,8 +1786,9 @@ private:
 	{
 		uint64_t disp64 = e.getDisp();
 #ifdef XBYAK64
-		uint64_t high = disp64 >> 32;
-		if (high != 0 && high != 0xFFFFFFFF) XBYAK_THROW(ERR_OFFSET_IS_TOO_BIG)
+		// displacement should be a signed 32-bit value, so also check sign bit
+		uint64_t high = disp64 >> 31;
+		if (high != 0 && high != 0x1FFFFFFFF) XBYAK_THROW(ERR_OFFSET_IS_TOO_BIG)
 #endif
 		uint32_t disp = static_cast<uint32_t>(disp64);
 		const Reg& base = e.getBase();


### PR DESCRIPTION
Hi, I think that since the 32-bit displacement is interpreted as a signed value, the sign bit should match the high bits of the 64-bit representation of the displacement. Otherwise, conversion to s32 value can truncate and something like 2^31 can be interpreted as -2^31.