### PR TITLE
build(make): fix clean target in test/Makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -95,7 +95,7 @@ test:
 	$(MAKE) test_avx512
 
 clean:
-	rm -rf *.o $(TARGET) lib_run nm.cpp nm_frame make_512
+	$(RM) *.asm *.lst *.obj *.o $(TARGET) lib_run nm.cpp nm_frame make_512
 
 lib_run: lib_test.cpp lib_run.cpp lib.h
 	$(CXX) $(CFLAGS) lib_run.cpp lib_test.cpp -o lib_run


### PR DESCRIPTION
.asm, .lst, and .obj files get generated during tests, and they should be cleaned up as well