### PR TITLE
build(make): honour CXXFLAGS, CPPFLAGS and LDFLAGS

### DIFF
--- a/gen/Makefile
+++ b/gen/Makefile
@@ -1,6 +1,6 @@
 TARGET=../xbyak/xbyak_mnemonic.h
 BIN=sortline gen_code gen_avx512
-CFLAGS=-I../ -O2 -DXBYAK_NO_OP_NAMES -Wall -Wextra -Wno-missing-field-initializers
+CFLAGS=-I../ -O2 -DXBYAK_NO_OP_NAMES -Wall -Wextra -Wno-missing-field-initializers $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
 all: $(TARGET) ../CMakeLists.txt ../meson.build
 sortline: sortline.cpp
 	$(CXX) $(CFLAGS) $< -o $@

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -51,7 +51,7 @@ all: $(TARGET)
 
 CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith #-pedantic
 
-CFLAGS=-g -O2 -fomit-frame-pointer -Wall -I../ $(CFLAGS_WARN)
+CFLAGS=-g -O2 -fomit-frame-pointer -Wall -I../ $(CFLAGS_WARN) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS)
 
 test:
 	$(CXX) $(CFLAGS) test0.cpp -o $@ -m32

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,7 +22,7 @@ all: $(TARGET)
 
 CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith
 
-CFLAGS=-O2 -fomit-frame-pointer -Wall -fno-operator-names -I../ -I./ $(CFLAGS_WARN) #-std=c++0x
+CFLAGS=-O2 -fomit-frame-pointer -Wall -fno-operator-names -I../ -I./ $(CFLAGS_WARN) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) #-std=c++0x
 make_nm:
 	$(CXX) $(CFLAGS) make_nm.cpp -o $@
 normalize_prefix: normalize_prefix.cpp ../xbyak/xbyak.h


### PR DESCRIPTION
It is currently impossible to pass custom flags to the makefiles using environment variables, because they ignore the predefined macros `CXXFLAGS`, `CPPFLAGS` and `LDFLAGS`.

Passing `LDFLAGS` is defined in the Posix standard (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/make.html#tag_20_76_13_09), while the `CXXFLAGS` and `CPPFLAGS` variables are predefined in GNU Make (https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html#Implicit-Variables).