### PR TITLE
MmapAllocator: take optional name parameter to be used with memfd

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -414,10 +414,14 @@ inline int getMacOsVersion()
 
 } // util
 #endif
-class MmapAllocator : Allocator {
+class MmapAllocator : public Allocator {
+	// Name of the memory region. Currently only used with XBYAK_USE_MEMFD.
+	const std::string name_;
 	typedef XBYAK_STD_UNORDERED_MAP<uintptr_t, size_t> SizeList;
 	SizeList sizeList_;
 public:
+	MmapAllocator() : name_("xbyak") {}
+	MmapAllocator(const std::string &name) : name_(name) {}
 	uint8_t *alloc(size_t size)
 	{
 		const size_t alignedSizeM1 = inner::ALIGN_PAGE_SIZE - 1;
@@ -435,7 +439,7 @@ public:
 #endif
 		int fd = -1;
 #if defined(XBYAK_USE_MEMFD)
-		fd = memfd_create("xbyak", MFD_CLOEXEC);
+		fd = memfd_create(name_.c_str(), MFD_CLOEXEC);
 		if (fd != -1) {
 			mode = MAP_SHARED;
 			if (ftruncate(fd, size) != 0) XBYAK_THROW_RET(ERR_CANT_ALLOC, 0)


### PR DESCRIPTION
By defining a per-allocator memfd, we can allow users to define the
names of their Xbyak-allocated memory regions. This can help users
obtain more meaningful profiles with tools such as perf(1).

For example, take oneDNN, which instantiates a CodeGenerator for
each operation. Before this patch, from perf(1) we cannot discern
which oneDNN operations were executed since they are all assigned
to "xbyak":

```
$ perf report -i /tmp/before.perf --stdio | egrep '(Overhead|xbyak)' | head -10
# Overhead  Command          Shared Objec             Symbol
     0.50%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000000cc
     0.49%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000000e0
     0.47%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000000f4
     0.38%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000000ba
     0.29%  benchmark        memfd:xbyak (deleted)    [.] 0x0000000000000139
     0.28%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000001e8
     0.27%  benchmark        memfd:xbyak (deleted)    [.] 0x00000000000001ad
     0.26%  benchmark        memfd:xbyak (deleted)    [.] 0x0000000000000172
     0.20%  benchmark        memfd:xbyak (deleted)    [.] 0x000000000000029c
     0.19%  benchmark        memfd:xbyak (deleted)    [.] 0x0000000000000234
```

After this patch (and after updating oneDNN to use a per-op MmapAllocator
with the appropriate name, i.e. "/oneDNN:$op"), we can:

```
$ perf report -i /tmp/after.perf --stdio | egrep '(Overhead|oneDNN)' | head -10
# Overhead  Command          Shared Object                                              Symbol
     0.47%  benchmark        oneDNN:jit_avx_gemv_t_f32_kern (deleted)                   [.] 0x00000000000000e0
     0.47%  benchmark        oneDNN:jit_avx_gemv_t_f32_kern (deleted)                   [.] 0x00000000000000cc
     0.44%  benchmark        oneDNN:jit_avx_gemv_t_f32_kern (deleted)                   [.] 0x00000000000000f4
     0.33%  benchmark        oneDNN:jit_avx_gemv_t_f32_kern (deleted)                   [.] 0x00000000000000ba
     0.25%  benchmark        oneDNN:inner_product_utils::jit_pp_kernel_t (deleted)      [.] 0x0000000000000139
     0.22%  benchmark        oneDNN:inner_product_utils::jit_pp_kernel_t (deleted)      [.] 0x0000000000000172
     0.22%  benchmark        oneDNN:inner_product_utils::jit_pp_kernel_t (deleted)      [.] 0x00000000000001ad
     0.21%  benchmark        oneDNN:inner_product_utils::jit_pp_kernel_t (deleted)      [.] 0x00000000000001e8
     0.17%  benchmark        oneDNN:jit_avx512_common_gemm_f32_xbyak_gemm (deleted)     [.] 0x0000000000000234
     0.14%  benchmark        oneDNN:jit_avx512_core_gemm_bf16bf16f32_kern (deleted)     [.] 0x000000000000087a
```