### PR TITLE
memfd_create: fix build for ANDROID_API < 30

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -95,7 +95,9 @@
 	#include <stdint.h>
 #endif
 
-#if !defined(MFD_CLOEXEC) // defined only linux 3.17 or later
+// MFD_CLOEXEC defined only linux 3.17 or later.
+// Android wraps the memfd_create syscall from API version 30.
+#if !defined(MFD_CLOEXEC) || (defined(__ANDROID__) && __ANDROID_API__ < 30)
 	#undef XBYAK_USE_MEMFD
 #endif
 


### PR DESCRIPTION
The syscall is wrapped in Bionic from API version 30:
  https://android.googlesource.com/platform/bionic.git/+/3d24d2b0883e%5E!/

This fixes the build for earlier versions of Android. Note that
MDF_CLOEXEC as well as the raw syscall numbers for memfd_create
were added much earlier:
  https://android.googlesource.com/platform/bionic.git/+/82d7504cd7d5%5E!/