### PR TITLE
Fix error related to XBYAK_NOEXCEPT

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -118,7 +118,7 @@
 	#endif
 #endif
 
-#if (__cplusplus >= 201103) || (defined(_MSC_VER) && _MSC_VER >= 1800)
+#if (__cplusplus >= 201103) || (defined(_MSC_VER) && _MSC_VER >= 1900)
 	#undef XBYAK_TLS
 	#define XBYAK_TLS thread_local
 	#define XBYAK_VARIADIC_TEMPLATE


### PR DESCRIPTION
The C++ keyword `noexcept` is not supported before Visual Studio 2015. This can be confirmed from [here](https://docs.microsoft.com/en-us/previous-versions/hh567368(v=vs.140)).