### PR TITLE
test: simplify makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -56,11 +56,11 @@ noexception: noexception.cpp ../xbyak/xbyak.h
 test_nm: normalize_prefix $(TARGET)
 	$(MAKE) -C ../gen
 ifneq ($(ONLY_64BIT),1)
-	env CXX=$(CXX) sh -e ./test_nm.sh
-	env CXX=$(CXX) sh -e ./test_nm.sh noexcept
-	env CXX=$(CXX) sh -e ./test_nm.sh Y
-	env CXX=$(CXX) sh -e ./test_nm.sh avx512
-	env CXX=$(CXX) sh -e ./test_address.sh
+	CXX=$(CXX) ./test_nm.sh
+	CXX=$(CXX) ./test_nm.sh noexcept
+	CXX=$(CXX) ./test_nm.sh Y
+	CXX=$(CXX) ./test_nm.sh avx512
+	CXX=$(CXX) ./test_address.sh
 	./jmp
 	./cvt_test32
 endif
@@ -69,36 +69,36 @@ endif
 	./misc32
 	./cvt_test
 ifeq ($(BIT),64)
-	env CXX=$(CXX) sh -e ./test_address.sh 64
+	CXX=$(CXX) ./test_address.sh 64
 ifneq ($(X32),1)
-	env CXX=$(CXX) sh -e ./test_nm.sh 64
-	env CXX=$(CXX) sh -e ./test_nm.sh Y64
+	CXX=$(CXX) ./test_nm.sh 64
+	CXX=$(CXX) ./test_nm.sh Y64
 endif
 	./jmp64
 endif
 
 test_avx: normalize_prefix
 ifneq ($(ONLY_64BIT),0)
-	env CXX=$(CXX) sh -e ./test_avx.sh
-	env CXX=$(CXX) sh -e ./test_avx.sh Y
+	CXX=$(CXX) ./test_avx.sh
+	CXX=$(CXX) ./test_avx.sh Y
 endif
 ifeq ($(BIT),64)
-	env CXX=$(CXX) sh -e ./test_avx.sh 64
+	CXX=$(CXX) ./test_avx.sh 64
 ifneq ($(X32),1)
-	env CXX=$(CXX) sh -e ./test_avx.sh Y64
+	CXX=$(CXX) ./test_avx.sh Y64
 endif
 endif
 
 test_avx512: normalize_prefix
 ifneq ($(ONLY_64BIT),0)
-	env CXX=$(CXX) sh -e ./test_avx512.sh
+	CXX=$(CXX) ./test_avx512.sh
 endif
 ifeq ($(BIT),64)
-	env CXX=$(CXX) sh -e ./test_avx512.sh 64
+	CXX=$(CXX) ./test_avx512.sh 64
 endif
 
 detect_x32: detect_x32.c
-	$(CC) $< -o $@
+	$(CC) $(CFLAGS) $< -o $@
 
 test: detect_x32
 	$(MAKE) test_nm

--- a/test/test_address.sh
+++ b/test/test_address.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 FILTER="grep -v warning"
 
 sub()

--- a/test/test_avx.sh
+++ b/test/test_avx.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 FILTER="grep -v warning"
 CXX=${CXX:=g++}
 

--- a/test/test_avx512.sh
+++ b/test/test_avx512.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 FILTER="grep -v warning"
 CXX=${CXX:=g++}
 

--- a/test/test_nm.sh
+++ b/test/test_nm.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 FILTER=cat
 CXX=${CXX:=g++}
 


### PR DESCRIPTION
Also add `$(CFLAGS)` to the detect_x32 target as they may be required to successfully detect the host system.