### PR TITLE
ci: use containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,21 @@
 name: test
 on: [push]
 
+defaults:
+  run:
+    shell: sh
+
+permissions:
+  contents: read
+
 jobs:
-  build:
-    name: test
+  test:
     runs-on: ubuntu-latest
+    container:
+      image: debian:testing
     steps:
-    - uses: actions/checkout@v2
-    - run: sudo apt update
-    - run: sudo apt install yasm g++-multilib tcsh
-    - run: wget https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz
-    - run: tar xvfz nasm-2.15.05.tar.gz && cd nasm-2.15.05 && ./configure && make && sudo make install && cd ..
+    - uses: actions/checkout@v3
+    - run: apt -y update
+    - run: apt -y install g++-multilib libboost-dev make nasm yasm
     - run: make test
     - run: make -C sample CXXFLAGS="-DXBYAK_NO_EXCEPTION"

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,9 +1,7 @@
 XBYAK_INC=../xbyak/xbyak.h
 CXX?=g++
 
-#BOOST_EXIST=$(shell echo "#include <boost/spirit/core.hpp>" | $(CXX) -x c++ -c - 2>/dev/null && echo 1)
-# I don't know why the above code causes an error on GitHub action.
-BOOST_EXIST?=0
+BOOST_EXIST=$(shell echo "#include <boost/spirit/core.hpp>" | $(CXX) -x c++ -c - 2>/dev/null && echo 1)
 UNAME_M=$(shell uname -m)
 
 ONLY_64BIT=0


### PR DESCRIPTION
GitHub's CI default runners are full of all kinds of software, and this can cause hard to reproduce errors. Luckly, GitHub Actions supports running jobs in a container image, so that the build environment is minimal and reprocucible.

This patch changes the main CI job to run in a Debian Testing container, fixing the issues described in
<https://github.com/herumi/xbyak/commit/cfb1127c3bf28d55e68b367a0a6944829a5c025d>.

As Debian Testing is a semi-rolling relase distribution, and nasm 2.15 is shipped by default, I've also modified the script to install nasm from apt instead of building it from source.