### PR TITLE
Allow constexpr TypeT `operator|`

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -93,7 +93,7 @@ struct TypeT {
 };
 
 template<uint64_t L1, uint64_t H1, uint64_t L2, uint64_t H2>
-TypeT<L1 | L2, H1 | H2> operator|(TypeT<L1, H1>, TypeT<L2, H2>) { return TypeT<L1 | L2, H1 | H2>(); }
+XBYAK_CONSTEXPR TypeT<L1 | L2, H1 | H2> operator|(TypeT<L1, H1>, TypeT<L2, H2>) { return TypeT<L1 | L2, H1 | H2>(); }
 
 template<typename T>
 inline T max_(T x, T y) { return x >= y ? x : y; }


### PR DESCRIPTION
This allows for a compile-time alias of multiple CPU flag types:

```
Xbyak::util::Cpu host_caps;
...
using namespace Xbyak::util;

static constexpr auto AVX512Ortho = Cpu::tAVX512F | Cpu::tAVX512VL;
static constexpr auto AVX512OrthoFloat = AVX512Ortho | Cpu::tAVX512DQ;

if (host_caps.has(AVX512Ortho))
{
    ...
}
```