### PR TITLE
build(cmake): bump minimum required to version 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,53 +1,49 @@
-cmake_minimum_required(VERSION 2.6...3.0.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(xbyak LANGUAGES CXX VERSION 6.73)
 
 file(GLOB headers xbyak/*.h)
 
-if (DEFINED CMAKE_VERSION AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.2)
-	include(GNUInstallDirs)
-	add_library(${PROJECT_NAME} INTERFACE)
-	add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-	
-	target_include_directories(
-		${PROJECT_NAME} INTERFACE
-		"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
-		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-	)
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-	install(
-		TARGETS ${PROJECT_NAME}
-		EXPORT ${PROJECT_NAME}-targets
-		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
-	)
+target_include_directories(
+	${PROJECT_NAME} INTERFACE
+	"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+	"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
-	include(CMakePackageConfigHelpers)
-	configure_package_config_file(
-		cmake/config.cmake.in
+install(
+	TARGETS ${PROJECT_NAME}
+	EXPORT ${PROJECT_NAME}-targets
+	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+	cmake/config.cmake.in
+	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+	INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
+write_basic_package_version_file(
+	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
+	COMPATIBILITY SameMajorVersion
+)
+
+install(
+	FILES
 		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-		INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-	)
-	write_basic_package_version_file(
 		"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-		COMPATIBILITY SameMajorVersion
-	)
+	DESTINATION
+		${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
 
-	install(
-		FILES
-			"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-			"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-		DESTINATION
-			${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-	)
-
-	install(
-		EXPORT ${PROJECT_NAME}-targets
-		NAMESPACE ${PROJECT_NAME}::
-		DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-	)
-elseif(NOT DEFINED CMAKE_INSTALL_INCLUDEDIR)
-	set(CMAKE_INSTALL_INCLUDEDIR "include")
-endif()
+install(
+	EXPORT ${PROJECT_NAME}-targets
+	NAMESPACE ${PROJECT_NAME}::
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
 
 install(
 	FILES ${headers}


### PR DESCRIPTION
With CMake 3.27, the following deprecation warning is visible:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
Compatibility with CMake < 3.5 will be removed from a future version of
CMake.

Update the VERSION argument <min> value or use a ...<max> suffix to tell
CMake that the project does not need compatibility with older versions.
```

Version 3.5 was released in March 2016 and is available on Ubuntu 14.04 (package `cmake3`) and later