### PR TITLE
support building for arm64ec

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -27,7 +27,7 @@
 #include "xbyak.h"
 #endif // XBYAK_ONLY_CLASS_CPU
 
-#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#if defined(__i386__) || (defined(__x86_64__) && !defined(__arm64ec__)) || defined(_M_IX86) || (defined(_M_X64) && !defined(_M_ARM64EC))
 	#define XBYAK_INTEL_CPU_SPECIFIC
 #endif
 


### PR DESCRIPTION
ARM64EC is a custom ABI designed to allow ARM64 code to directly call into x64 code and vice-versa. In order to facilitate this, `__x86_64__` (in llvm) and _M_X64 (in msvc) are both defined, but most x64 intrinsics aren't supported, so don't attempt to use them.