### PR TITLE
support align for auto_grow

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -3215,7 +3215,7 @@ public:
 	{
 		if (x == 1) return;
 		if (x < 1 || (x & (x - 1))) XBYAK_THROW(ERR_BAD_ALIGN)
-		if (isAutoGrow()) XBYAK_THROW(ERR_BAD_ALIGN)
+		if (isAutoGrow() && inner::getPageSize() % x != 0) XBYAK_THROW(ERR_BAD_ALIGN)
 		size_t remain = size_t(getCurr()) % x;
 		if (remain) {
 			nop(x - remain, useMultiByteNop);


### PR DESCRIPTION
This commit 33882d0a0906c61455324cd69d8372460e23741c has removed support for `align` with `Auto grow` enabled. Re-enabling it.

Please let me know if there were any other issues that blocks enabling it.