### PR TITLE
FIX: extractBit() off-by-one issue.

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -177,7 +177,7 @@ private:
 	}
 	uint32_t extractBit(uint32_t val, uint32_t base, uint32_t end)
 	{
-		return (val >> base) & ((1u << (end - base)) - 1);
+		return (val >> base) & ((1u << (end + 1 - base)) - 1);
 	}
 	void setNumCores()
 	{


### PR DESCRIPTION
Currently while extracting bits, the last bit specified by the "end" parameter is excluded from the result while, based on usage, it is expected to be included.