### PR TITLE
build(meson): arch-independent fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,7 @@ project(
 	default_options: 'b_ndebug=if-release'
 )
 
-include_dir = get_option('prefix') / get_option('includedir')
-install_subdir('xbyak', install_dir: include_dir)
+install_subdir('xbyak', install_dir: get_option('includedir'))
 
 xbyak_dep = declare_dependency(include_directories: include_directories('.'))
 
@@ -24,18 +23,18 @@ import('pkgconfig').generate(
 	description: 'JIT assembler for x86(IA32), x64(AMD64, x86-64)',
 	version: meson.project_version(),
 	url: 'https://github.com/herumi/xbyak',
-	variables: ['includedir=@0@'.format(include_dir)],
-	dataonly: true,
+	install_dir: get_option('datadir')/'pkgconfig'
 )
 
-shared_cmake_dir = get_option('prefix') / 'share/cmake/xbyak'
-if meson.version().version_compare('>=0.50.0')
+if meson.version().version_compare('>=0.62.0')
 	cmake = import('cmake')
+	shared_cmake_dir = get_option('datadir')/'cmake'/meson.project_name()
 
 	cmake.write_basic_package_version_file(
 		name: meson.project_name(),
 		version: meson.project_version(),
 		install_dir: shared_cmake_dir,
+		arch_independent: true
 	)
 
 	cmake_conf = configuration_data()


### PR DESCRIPTION
This patch fixes a couple of issues introduced in commits c7c1eac070851068d7adc3a67ad2efd196145687 and
9f535729159baf467c3bd8dc7ec017a40289a12c:

- Dropped `dataonly: true` from `pkgconfig.generate()`, since it generates a .pc file unsuitable for libraries. Instead, I've just set `install_dir` to `$datadir/pkgconfig`, which generates the following:

      $ cat /usr/share/pkgconfig/xbyak.pc
      prefix=/usr
      includedir=${prefix}/include

      Name: xbyak
      Description: JIT assembler for x86(IA32), x64(AMD64, x86-64)
      URL: https://github.com/herumi/xbyak
      Version: 7.06
      Cflags: -I${includedir}

- Changed `share/cmake/xbyak` to `get_option('datadir')/'cmake'/meson.project_name()` to avoid hardcoding "share" as the datadir.

- Added `arch_independent: true` to the `cmake.write_basic_package_version_file()` call so that the generated CMake version file doesn't contain arch-specific checks unsuitable for a file located in /usr/share/cmake.

Cc: @keszybz 