### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: debian:testing
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: apt -y update
     - run: apt -y install g++-multilib libboost-dev make nasm yasm
     - run: make test


### PR DESCRIPTION
Fix warning:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.