### PR TITLE
add cvt128, cvt256, cvt512 convenience functions

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -836,12 +836,17 @@ struct EvexModifierRounding {
 };
 struct EvexModifierZero{ XBYAK_CONSTEXPR EvexModifierZero() {}};
 
+struct Ymm;
+struct Zmm;
 struct Xmm : public Mmx {
 	explicit XBYAK_CONSTEXPR Xmm(int idx = 0, Kind kind = Operand::XMM, int bit = 128) : Mmx(idx, kind, bit) { }
 	XBYAK_CONSTEXPR Xmm(Kind kind, int idx) : Mmx(idx, kind, kind == XMM ? 128 : kind == YMM ? 256 : 512) { }
 	Xmm operator|(const EvexModifierRounding& emr) const { Xmm r(*this); r.setRounding(emr.rounding); return r; }
 	Xmm copyAndSetIdx(int idx) const { Xmm ret(*this); ret.setIdx(idx); return ret; }
 	Xmm copyAndSetKind(Operand::Kind kind) const { Xmm ret(*this); ret.setKind(kind); return ret; }
+	Xmm cvt128() const;
+	Ymm cvt256() const;
+	Zmm cvt512() const;
 };
 
 struct Ymm : public Xmm {
@@ -937,6 +942,21 @@ inline Reg64 Reg::cvt64() const
 	return Reg64(changeBit(64).getIdx());
 }
 #endif
+
+inline Xmm Xmm::cvt128() const
+{
+	return Xmm(changeBit(128).getIdx());
+}
+
+inline Ymm Xmm::cvt256() const
+{
+	return Ymm(changeBit(256).getIdx());
+}
+
+inline Zmm Xmm::cvt512() const 
+{
+	return Zmm(changeBit(512).getIdx());
+}
 
 #ifndef XBYAK_DISABLE_SEGMENT
 // not derived from Reg


### PR DESCRIPTION
While the functionality to access, for example, `al` from `eax` by calling `reg.cvt8()` exists, this does not exist for `xmm`/`ymm`/`zmm` registers. This is useful, for example, when one has a `ymm` register being initialized from a 128-bit load, implicitly zeroing the upper part, by doing `vmovdqa(ymm.cvt128(), xword[...])`.

This PR adds this functionality in what I think is the most straightforward way possible.