### PR TITLE
CMake: Bump minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 project(xbyak LANGUAGES CXX VERSION 7.24)
 


### PR DESCRIPTION
For the same purpose as [**this PR**](https://github.com/herumi/xbyak/pull/178).
Since CMake 3.31.0, the minimum version below 3.10 generates a warning.