### PR TITLE
Fix improper encoding of APX instructions with NDD format.

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -2276,7 +2276,7 @@ private:
 		int opBit = op.getBit();
 		if (disableRex && opBit == 64) opBit = 32;
 		const Reg r(ext, Operand::REG, opBit);
-		if ((type & T_APX) && op.hasRex2NFZU() && opROO(d ? *d : Reg(0, Operand::REG, opBit), op, r, type, code)) return;
+		if ((type & T_APX) && (d != 0) && opROO(*d, op, r, type, code)) return;
 		if (op.isMEM()) {
 			opMR(op.getAddress(immSize), r, type, code);
 		} else if (op.isREG(bit)) {

--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -517,6 +517,7 @@ void hsubps(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_F2|T_0F|T_YMM,
 void idiv(const Operand& op) { opRext(op, 0, 7, T_APX|T_NF|T_CODE1_IF1, 0xF6); }
 void imul(const Operand& op) { opRext(op, 0, 5, T_APX|T_NF|T_CODE1_IF1, 0xF6); }
 void imul(const Reg& reg, const Operand& op) { if (opROO(Reg(), op, reg, T_APX|T_NF, 0xAF)) return; opRO(reg, op, T_0F, 0xAF, reg.getKind() == op.getKind()); }
+void imul(const Reg& d, const Reg& reg, const Operand& op) { opROO(d, op, reg, T_APX|T_ND1|T_NF, 0xAF); }
 void in_(const Reg& a, const Reg& d) { opInOut(a, d, 0xEC); }
 void in_(const Reg& a, uint8_t v) { opInOut(a, 0xE4, v); }
 void inc(const Operand& op) { opIncDec(Reg(), op, 0); }


### PR DESCRIPTION
These source changes fix the lack of APX encoding for instructions with New Data Destination format (NDD): SAL, SAR, SHL, SHR, RCL, RCR, ROL, ROR, and IMUL.

Xbyak doesn't produce NDD encoding for some instructions unless they use r16-r31 as input.
For example, this sequence:
```asm
     sal(rax, r8,   1);
     sar(rax, r9,   4);
     shl(rax, rdi,  8);
     shr(rax, rsi, 12);
     rcl(rax, r10, 16);
     rcr(rax, r11, 20);
     rol(rax, r14, 24);
     ror(rax, r15, 28);
     sal(rcx, qword[r8],  32);
     sar(rcx, qword[r9],  36);
     sal(rcx, qword[rdi], 40);
     sar(rcx, qword[rsi], 44);
     rcl(rcx, qword[r10], 48);
     rcr(rcx, qword[r11], 52);
     rol(rcx, qword[r14], 56);
     ror(rcx, qword[r15], 60);
```
is produced into this binary:
```asm
   49 d1 e0                shl    r8,1
   49 c1 f9 04             sar    r9,0x4
   48 c1 e7 08             shl    rdi,0x8
   48 c1 ee 0c             shr    rsi,0xc
   49 c1 d2 10             rcl    r10,0x10
   49 c1 db 14             rcr    r11,0x14
   49 c1 c6 18             rol    r14,0x18
   49 c1 cf 1c             ror    r15,0x1c
   49 c1 20 20             shl    QWORD PTR [r8],0x20
   49 c1 39 24             sar    QWORD PTR [r9],0x24
   48 c1 27 28             shl    QWORD PTR [rdi],0x28
   48 c1 3e 2c             sar    QWORD PTR [rsi],0x2c
   49 c1 12 30             rcl    QWORD PTR [r10],0x30
   49 c1 1b 34             rcr    QWORD PTR [r11],0x34
   49 c1 06 38             rol    QWORD PTR [r14],0x38
   49 c1 0f 3c             ror    QWORD PTR [r15],0x3c
```
Instead of using APX instruction encoding, the target registers were just skipped, NDD format was not recognized, the source registers and memory were overwritten.
Although using r16-r31 in the sequence allows the NDD format to be recognized and APX instructions to be encoded properly:
```asm
     sal(rax, r16,  1);
     sar(rax, r17,  4);
     shl(rax, r18,  8);
     shr(rax, r19, 12);
     rcl(rax, r24, 16);
     rcr(rax, r25, 20);
     rol(rax, r26, 24);
     ror(rax, r27, 28);
     sal(rcx, qword[r16], 32);
     sar(rcx, qword[r17], 36);
     sal(rcx, qword[r18], 40);
     sar(rcx, qword[r19], 44);
     rcl(rcx, qword[r24], 48);
     rcr(rcx, qword[r25], 52);
     rol(rcx, qword[r26], 56);
     ror(rcx, qword[r27], 60);
```
It's produced into this binary:
```asm
   62 fc fc 18 d1 e0       shl    rax,r16,1
   62 fc fc 18 c1 f9 04    sar    rax,r17,0x4
   62 fc fc 18 c1 e2 08    shl    rax,r18,0x8
   62 fc fc 18 c1 eb 0c    shr    rax,r19,0xc
   62 dc fc 18 c1 d0 10    rcl    rax,r24,0x10
   62 dc fc 18 c1 d9 14    rcr    rax,r25,0x14
   62 dc fc 18 c1 c2 18    rol    rax,r26,0x18
   62 dc fc 18 c1 cb 1c    ror    rax,r27,0x1c
   62 fc f4 18 c1 20 20    shl    rcx,QWORD PTR [r16],0x20
   62 fc f4 18 c1 39 24    sar    rcx,QWORD PTR [r17],0x24
   62 fc f4 18 c1 22 28    shl    rcx,QWORD PTR [r18],0x28
   62 fc f4 18 c1 3b 2c    sar    rcx,QWORD PTR [r19],0x2c
   62 dc f4 18 c1 10 30    rcl    rcx,QWORD PTR [r24],0x30
   62 dc f4 18 c1 19 34    rcr    rcx,QWORD PTR [r25],0x34
   62 dc f4 18 c1 02 38    rol    rcx,QWORD PTR [r26],0x38
   62 dc f4 18 c1 0b 3c    ror    rcx,QWORD PTR [r27],0x3c
```
Here is the binary output after using this fix:
```asm
   62 d4 fc 18 d1 e0       shl    rax,r8,1
   62 d4 fc 18 c1 f9 04    sar    rax,r9,0x4
   62 f4 fc 18 c1 e7 08    shl    rax,rdi,0x8
   62 f4 fc 18 c1 ee 0c    shr    rax,rsi,0xc
   62 d4 fc 18 c1 d2 10    rcl    rax,r10,0x10
   62 d4 fc 18 c1 db 14    rcr    rax,r11,0x14
   62 d4 fc 18 c1 c6 18    rol    rax,r14,0x18
   62 d4 fc 18 c1 cf 1c    ror    rax,r15,0x1c
   62 d4 f4 18 c1 20 20    shl    rcx,QWORD PTR [r8],0x20
   62 d4 f4 18 c1 39 24    sar    rcx,QWORD PTR [r9],0x24
   62 f4 f4 18 c1 27 28    shl    rcx,QWORD PTR [rdi],0x28
   62 f4 f4 18 c1 3e 2c    sar    rcx,QWORD PTR [rsi],0x2c
   62 d4 f4 18 c1 12 30    rcl    rcx,QWORD PTR [r10],0x30
   62 d4 f4 18 c1 1b 34    rcr    rcx,QWORD PTR [r11],0x34
   62 d4 f4 18 c1 06 38    rol    rcx,QWORD PTR [r14],0x38
   62 d4 f4 18 c1 0f 3c    ror    rcx,QWORD PTR [r15],0x3c.
```
IMUL also has the NDD format (3-operand without imm), which was not implemented in Xbyak:
```asm
     imul(rax, rdx, r10);
     imul(rcx, r15, qword[rdi]);

   62 d4 fc 18 af d2       imul   rax,rdx,r10
   62 74 f4 18 af 3f       imul   rcx,r15,QWORD PTR [rdi]
```