### PR TITLE
Allow non-conflicting updates to OpmaskIdx and Rounding.

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -644,12 +644,12 @@ public:
 	void setBit(int bit);
 	void setOpmaskIdx(int idx, bool /*ignore_idx0*/ = true)
 	{
-		if (mask_) XBYAK_THROW(ERR_OPMASK_IS_ALREADY_SET)
+		if (mask_ && (mask_ != idx)) XBYAK_THROW(ERR_OPMASK_IS_ALREADY_SET)
 		mask_ = idx;
 	}
 	void setRounding(int idx)
 	{
-		if (rounding_) XBYAK_THROW(ERR_ROUNDING_IS_ALREADY_SET)
+		if (rounding_ && (rounding_ != idx)) XBYAK_THROW(ERR_ROUNDING_IS_ALREADY_SET)
 		rounding_ = idx;
 	}
 	void setZero() { zero_ = true; }


### PR DESCRIPTION
Disable errors on non-conflicting updates to OpmaskIdx and Rounding.

Current implementation rejects multiple calls to setOpmaskIdx with the same idx. The same is true about setRounding.

Proposed change disables error on multiple calls in case the idx value is not changing, eg.:
dst->setOpmaskIdx(1);
dst->setOpmaskIdx(1); // second call will cause error even though the idx is the same.