### PR TITLE
Add override specifiers to virtual methods and -Wsuggest-override flag

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ endif
 
 all: $(TARGET)
 
-CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wwrite-strings -Wfloat-equal -Wpointer-arith
+CFLAGS_WARN=-Wall -Wextra -Wsuggest-override -Wformat=2 -Wcast-qual -Wwrite-strings -Wfloat-equal -Wpointer-arith
 
 CFLAGS=-O2 -Wall -I.. -I. $(CFLAGS_WARN) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) #-std=c++0x
 make_nm:

--- a/test/jmp.cpp
+++ b/test/jmp.cpp
@@ -588,7 +588,7 @@ uint8_t bufL[4096 * 32];
 uint8_t bufS[4096 * 2];
 
 struct MyAllocator : Xbyak::Allocator {
-	uint8_t *alloc(size_t size)
+	uint8_t *alloc(size_t size) XBYAK_OVERRIDE
 	{
 		if (size < sizeof(bufS)) {
 			printf("test use bufS(%d)\n", (int)size);
@@ -601,7 +601,7 @@ struct MyAllocator : Xbyak::Allocator {
 		fprintf(stderr, "no memory %d\n", (int)size);
 		exit(1);
 	}
-	void free(uint8_t *)
+	void free(uint8_t *) XBYAK_OVERRIDE
 	{
 	}
 } myAlloc;

--- a/test/noexception.cpp
+++ b/test/noexception.cpp
@@ -56,7 +56,7 @@ void test2()
 void test3()
 {
 	static struct EmptyAllocator : Xbyak::Allocator {
-		uint8_t *alloc(size_t) { return 0; }
+		uint8_t *alloc(size_t) XBYAK_OVERRIDE { return 0; }
 	} emptyAllocator;
 	struct Code : CodeGenerator {
 		Code() : CodeGenerator(8, 0, &emptyAllocator)

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -123,8 +123,10 @@
 	#define XBYAK_TLS thread_local
 	#define XBYAK_VARIADIC_TEMPLATE
 	#define XBYAK_NOEXCEPT noexcept
+	#define XBYAK_OVERRIDE override
 #else
 	#define XBYAK_NOEXCEPT throw()
+	#define XBYAK_OVERRIDE
 #endif
 
 // require c++14 or later
@@ -340,7 +342,7 @@ public:
 		}
 	}
 	operator int() const { return err_; }
-	const char *what() const XBYAK_NOEXCEPT
+	const char *what() const XBYAK_NOEXCEPT XBYAK_OVERRIDE
 	{
 		return ConvertErrorToString(err_);
 	}
@@ -495,7 +497,7 @@ class MmapAllocator : public Allocator {
 	AllocationList allocList_;
 public:
 	explicit MmapAllocator(const std::string& name = "xbyak") : name_(name) {}
-	uint8_t *alloc(size_t size)
+	uint8_t *alloc(size_t size) XBYAK_OVERRIDE
 	{
 		const size_t alignedSizeM1 = inner::getPageSize() - 1;
 		size = (size + alignedSizeM1) & ~alignedSizeM1;
@@ -534,7 +536,7 @@ public:
 #endif
 		return (uint8_t*)p;
 	}
-	void free(uint8_t *p)
+	void free(uint8_t *p) XBYAK_OVERRIDE
 	{
 		if (p == 0) return;
 		AllocationList::iterator i = allocList_.find((uintptr_t)p);


### PR DESCRIPTION
Intention of this patch is to support clean build with stricter compiler settings.
Related patch in xbyak_riscv: https://github.com/herumi/xbyak_riscv/pull/19