### PR TITLE
RegExp(const void*): make constructor explicit to fix integer literal ambiguity

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1019,7 +1019,7 @@ public:
 	}
 	RegExp(Label& label);
 
-	RegExp(const void *addr)
+	explicit RegExp(const void *addr)
 		: scale_(1)
 		, disp_(size_t(addr))
 		, label_(0)


### PR DESCRIPTION
# Problem

xbyak 7.33.2+ added a `RegExp(const void* addr)` constructor alongside the existing `RegExp(size_t disp)`. This introduces an ambiguity for any integer constant expression equal to zero, because in C++ a zero-valued integer constant is a null pointer constant and implicitly converts to both `size_t` and `const void*`.

The pre-7.33.2 single constructor `RegExp(size_t disp = 0)` handled this safely — `RegExp(0)` simply called `RegExp(size_t)`. The 7.33.2 split into `RegExp()` + `RegExp(size_t)` + `RegExp(const void*)` breaks this for any code using `0` as a displacement.

# Minimal reproducer

```
Xbyak::RegExp e = 0 + rsp;  // error: conversion from 'int' to 'const Xbyak::RegExp' is ambiguous
                            // candidates: RegExp(size_t), RegExp(const void*)
```
This is a natural pattern in code that builds address expressions conditionally:

```
// Fails to compile with 7.33.2:
ptr[aux_reg + (i ? stride_reg * i : 0) + offset]
//                                  ^ ambiguous: size_t or const void*?
```
And in macro-defined stack slot offsets, also common in code generators:

```
#define SLOT_0 (0 + rsp)   // error: ambiguous conversion of 0
#define SLOT_8 (8 + rsp)   // fine: 8 can only be size_t
```
Note that only `0` (and any compile-time constant expression that evaluates to zero) is affected — non-zero integer literals are unambiguous because they cannot convert to `const void*`.

# Fix

Mark `RegExp(const void* addr)` as `explicit`. This is the correct constraint: passing a raw pointer to a `RegExp` is always an intentional act that deserves an explicit cast, not something that should happen silently from an integer literal. All existing call sites of the form `RegExp(somePointer)` continue to work since those are already explicit expressions.

```
// Before:
RegExp(const void *addr) ...

// After:
explicit RegExp(const void *addr) ...
```

This restores the pre-7.33.2 behavior — `RegExp(0)` and `0 + reg` unambiguously call `RegExp(size_t)` — without adding any new overloads.