### PR TITLE
`Address`: add default constructor to support use as a class member

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1366,8 +1366,12 @@ public:
 
 class Address : public Operand {
 public:
+	XBYAK_CONSTEXPR Address()
+		: Operand(0, MEM, 0), e_(), label_(NULL), mode_(inner::M_ModRM), immSize(0),
+		  disp8N(0), permitVsib(false), broadcast_(false), optimize_(true) { }
 	XBYAK_CONSTEXPR Address(uint32_t sizeBit, bool broadcast, const RegExp& e)
-		: Operand(0, MEM, sizeBit), e_(e), label_(e.label_), mode_(), immSize(0), disp8N(0), permitVsib(false), broadcast_(broadcast), optimize_(true)
+		: Operand(0, MEM, sizeBit), e_(e), label_(e.label_), mode_(), immSize(0),
+		  disp8N(0), permitVsib(false), broadcast_(broadcast), optimize_(true)
 	{
 		if (e.rip_) {
 			mode_ = (e.label_ || e.setLabel_) ? inner::M_ripAddr : inner::M_rip;


### PR DESCRIPTION
# Problem

`Xbyak::Address` has no default constructor, which makes it impossible to use as a non-static class member without immediately providing a valid memory address at construction time. This is a common pattern in JIT kernel classes, where address operands are declared as members, initialized to a known-safe sentinel at construction, and then assigned their real values during code generation.

Without a default constructor the only workaround is `Address(size_t disp)`, which was removed in xbyak 7.33.2. This forces users to either store Address members in `std::optional<Address>`, use pointers, or add their own patch to Xbyak.

# Minimal reproducer

```
class MyKernel : public Xbyak::CodeGenerator {
    Xbyak::Address arg_a;   // error: no matching constructor for initialization
    Xbyak::Address arg_b;   // the type has no default constructor

    MyKernel() : arg_a(???), arg_b(???) { }
    //                   ^^^
    // No valid expression exists here until code generation begins.
    // The real values are assigned later once register state is known:
    //   arg_a_ = ptr[rsp + 0];
    //   arg_b_ = ptr[rsp + 8];};
```
# Fix

Add a default constructor that produces an inert, unaddressed `Address` with zero size and `M_ModRM` mode (consistent with how `RegExp()` default-constructs):

```
XBYAK_CONSTEXPR Address()
    : Operand(0, MEM, 0), e_(), label_(nullptr), mode_(M_ModRM),
      immSize(0), disp8N(0), permitVsib(false),
      broadcast_(false), optimize_(true) { }
```

With this in place the pattern compiles naturally:

```
class MyKernel : public Xbyak::CodeGenerator {
    Xbyak::Address arg_a_;
    Xbyak::Address arg_b_;

    MyKernel() : arg_a_(), arg_b_() { }
    //  or equivalently: arg_a_{}, arg_b_{}
};
```
# Notes

- The default-constructed `Address` is a sentinel — it should not be passed to an emit instruction without first being assigned a valid address. This matches the existing behavior of `Xbyak::Reg` and `Xbyak::RegExp`, both of which provide default constructors with analogous semantics.
- This does **not** restore the removed `Address(size_t disp)` constructor — the default constructor carries no address value and cannot be confused with an absolute 64-bit displacement.
- `constexpr` is conditional on `XBYAK_CONSTEXPR` for pre-C++11 compatibility, consistent with the rest of the class.