### PR TITLE
Fix undef error when building on macOS

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -1424,7 +1424,7 @@ inline bool initCpuTopology(CpuTopology& cpuTopo)
 	return true;
 }
 
-#elif __linux__ // Linux
+#elif defined(__linux__) // Linux
 
 struct WrapFILE {
 	FILE *f;


### PR DESCRIPTION
# Problem:
When building on macOS will give the following compiler warning:

```bash
error: '__linux__' is not defined, evaluates to 0 [-Werror,-Wundef]
#elif __linux__ // Linux
      ^
1 error generated.
```

this is caused by using `#elif __linux__` instead of `#elif defined(__linux__)`.

 On macOS, `__linux__` is not defined, so the preprocessor treats it as `0`, but `-Wundef` (and `-Werror`) make this a compiler error.
 
# Fix

The fix is easy change
```cpp
#elif __linux__
```
to
```cpp
#elif defined(__linux__)
```
This solution is portable and eliminates the warning/error everywhere.