### PR TITLE
Revert "keep backward compatibility of RegExp"

### DIFF
--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -159,16 +159,6 @@ CYBOZU_TEST_AUTO(mov_const)
 	} code;
 }
 
-CYBOZU_TEST_AUTO(RegExp)
-{
-	using namespace Xbyak::util;
-	Address defaultAddr; // default constructor
-	int x = 0;
-	eax + 0;
-	0 + eax;
-	eax + &x;
-}
-
 #ifdef XBYAK64
 CYBOZU_TEST_AUTO(mov_8byte)
 {

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1117,7 +1117,7 @@ inline RegExp operator*(int scale, const Reg& r)
 	return r * scale;
 }
 // backward compatibility for eax+0
-inline RegExp operator+(const RegExp& a, const void *b) { return a + RegExp(b); }
+inline RegExp operator+(const RegExp& a, size_t b) { return a + RegExp(b); }
 
 inline RegExp operator-(const RegExp& e, size_t disp)
 {
@@ -1453,14 +1453,6 @@ public:
 	Address operator[](const RegExp& e) const
 	{
 		return Address(bit_, broadcast_, e);
-	}
-	Address operator[](const void *addr) const
-	{
-		return operator[](RegExp(addr));
-	}
-	Address operator[](uint64_t offset) const
-	{
-		return operator[](RegExp(offset));
 	}
 };
 


### PR DESCRIPTION
This reverts commit 9c0fec37712e3ae60bb3cfd86433d4228458e514.

**Root cause:** C++ null pointer constant overload hijacking
**Background:** the upstream changes in xbyak 7.34.1 made two related signature changes:


```
// Before (7.33.3)
inline RegExp operator+(const RegExp& a, size_t b)      { return a + RegExp(b); }

// After (7.34.1)
inline RegExp operator+(const RegExp& a, const void* b) { return a + RegExp(b); }
```


```
// Before (7.33.3) — AddressFrame had no operator[](const void*) or operator[](uint64_t)

// After (7.34.1)
Address operator[](const void* addr)   const { return operator[](RegExp(addr)); }
Address operator[](uint64_t offset)    const { return operator[](RegExp(offset)); }
```

These two RegExp constructors have completely different semantics:


| Constructor                           | scale_	| setLabel_	| Effect                                      |
|---------------------------------------|-----------|-----------|---------------------------------------------|
|`RegExp(size_t disp)`                  | 0         | false     | Normal displacement — `[reg + disp]`        |
| `explicit RegExp(const void* addr)`	| 1         | true      | Absolute address — RIP/label-based encoding |

Routing through the wrong one silently generates a different instruction encoding.

The integer literal `0` is the landmine
In C++, the integer literal `0` (and any integral constant expression that evaluates to zero at compile time — including `0 * SIZE`, `0 * 16`, `args_offset + 0` where `args_offset` is `constexpr-zero`, etc.) is a null pointer constant. This means it implicitly converts to any pointer type, including `const void*`, with no cast required.

The standard conversion `int(0)` -> `const void*` ranks higher in overload resolution than the user-defined conversion `int(0)` -> `size_t` -> `RegExp(size_t)`. With both overloads present, the compiler silently picks `const void*`. (verified experimentally using GCC C++14)

**What broke at runtime for oneDNN:**
oneDNN's x64 JIT kernels contain 79 instances of patterns like:

```
vmovups(ptr[AO1 + (unroll_m * i + 0 * 16 - OFFSET) * SIZE], ...);
vmovups(VBIAS1, ptr[BIAS1 + 0 * SIZE]);
arg_c_ = ptr[rsp + (args_offset + 0)];
prefetchw(ptr[CO2 + 0 * 16 * SIZE]);
```

With the `size_t` overload, `reg + 0` -> `RegExp(size_t(0))` → plain `[reg + 0]` displacement (correct).

With the `const void*` overload, `reg + 0` -> `RegExp(nullptr)` -> `scale_ = 1`, `setLabel_ = true` -> absolute-address encoding mode, which then fails, causing runtime errors.

Why `AddressFrame::operator[](const void*)` was also dropped
The same null-pointer-constant promotion applies to `operator[]. ptr[0]` would silently route to `operator[](const void*)` -> `RegExp(nullptr)` -> absolute-address encoding, instead of `operator[](const RegExp&)` via `RegExp(size_t(0))` -> displacement. Since oneDNN JIT never addresses memory via a raw pointer through AddressFrame, both new overloads were pure risk with no benefit.

Fix applied
Revert commit `9c0fec37712e3ae60bb3cfd86433d4228458e514`.