### PR TITLE
implement NetBSD prot detail

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -533,7 +533,14 @@ public:
 			}
 		}
 #endif
-		void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, fd, 0);
+		int prot = PROT_READ | PROT_WRITE;
+#ifdef PROT_MPROTECT
+		// Some NetBSD systems have this protection turned on by default
+        // https://man.netbsd.org/mprotect.2 specifies that an mprotect() that is LESS
+        // restrictive than the original mapping MUST fail
+        prot |= PROT_MPROTECT(PROT_READ) | PROT_MPROTECT(PROT_WRITE) | PROT_MPROTECT(PROT_EXEC);
+#endif
+		void *p = mmap(NULL, size, prot, mode, fd, 0);
 		if (p == MAP_FAILED) {
 			if (fd != -1) close(fd);
 			XBYAK_THROW_RET(ERR_CANT_ALLOC, 0)


### PR DESCRIPTION
see comment

	// Some NetBSD systems have this protection turned on by default
        // https://man.netbsd.org/mprotect.2 specifies that an mprotect() that is LESS
        // restrictive than the original mapping MUST fail