### PR TITLE
fix: add int overload for RegExp::operator+ to resolve ambiguity with 0

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1024,7 +1024,7 @@ public:
 		, disp_(size_t(addr))
 		, label_(0)
 		, rip_(false)
-		, asPtr_(addr != NULL) // treat zero as an integer
+		, asPtr_(true) // treat zero as an integer
 	{
 	}
 #ifdef XBYAK64
@@ -1067,6 +1067,7 @@ public:
 		}
 	}
 	friend RegExp operator+(const RegExp& a, const RegExp& b);
+	friend RegExp operator+(const RegExp& e, size_t disp);
 	friend RegExp operator-(const RegExp& e, size_t disp);
 private:
 	/*
@@ -1116,8 +1117,19 @@ inline RegExp operator*(int scale, const Reg& r)
 {
 	return r * scale;
 }
-// backward compatibility for eax+0
-inline RegExp operator+(const RegExp& a, const void *b) { return a + RegExp(b); }
+
+// backward compatibility for eax+&x (pointer address)
+inline RegExp operator+(const RegExp& a, const void* b) { return a + RegExp(b); }
+
+// overload for integer literals (e.g. eax+0) to avoid ambiguity with the void* overload
+inline RegExp operator+(const RegExp& e, int disp) { return e + size_t(disp); }
+
+inline RegExp operator+(const RegExp& e, size_t disp)
+{
+	RegExp ret = e;
+	ret.disp_ += disp;
+	return ret;
+}
 
 inline RegExp operator-(const RegExp& e, size_t disp)
 {


### PR DESCRIPTION
Alternate solution to RegExp operator+. 

Developer note: Sorry I did not suggest this sooner. I did not know the solution used for the 7.35.1 release would result in clang-tidy warnings.

Reason this is wanted:
Add `operator+(const RegExp&, size_t)` and `operator+(const RegExp&, int)` to resolve clang-tidy warning and ambiguity with integer literal 0

## Problem

`operator-` already had a proper integer overload:
```cpp
inline RegExp operator-(const RegExp& e, size_t disp) { ... }
```

but `operator+` had no equivalent. This inconsistency caused two issues:

**1. Clang-tidy `modernize-use-nullptr` warning**

because `0` is implicitly converted to `const void*`, expresions like `rsp + 0` routed though the pointer overload, triggers clang-tidy warnings like.

```
warning: use nullptr [modernize-use-nullptr]
100 |    offset_a_ - qword[rsp + 0];
    |                            ^
	|                            nullptr
```

Replacing `0` with nullptr as clang-tidy suggest would be incorrect - the intent is an integer displacement of zero. The `explicit RegExp(const coid*)` constructor set `asPtr_ = addr != NULL)`, so passing `nullptr` would silently change the semantics of the expression.

**2. compilation error due to ambiguity**
Once `operator+(const RegExp&, size_t)` was added to mirror `operator-`, expressions like `eax + 0` became ambiguous: `0` is convertible to both `const void*` and `size_t` causing a compilation errors.

##Fix
Add the two missing overloads to mirror the existing `operator-`

```cpp
// mirrors operator-(const RegExp&, size_t)
inline RegExp operator+(const RegExp& e, size_t disp)
{
    RegExp ret = e;
    ret.disp_ += disp;
    return ret;
}

// resolves ambiguity for integer literals (e.g. eax+0) — exact match
// to int avoids the implicit int->void* conversion seen by clang-tidy
inline RegExp operator+(const RegExp& e, int disp) { return e + size_t(disp); }
```

With the int overload in place, `eax + 0` is and exact match and never flows into a pointer parameter, eliminating the clang-tidy warning.
The `const void*` overload is retained for genuine pointer-address uses.

|Expression | resolves to |
|----|-----|
| `eax + 0` | `operator+(const RexExp&, int)` |
|`eax + n` | `operator+(const RegExp&, size_t)` |
|`eax + &x` | `operator+(const RegExp&, const void*)`|

Now that there is no ambiguity for the operator+ the constructor `explicit RexExp(cont void *addr)` no longer needs to check for NULL and can set the `asPtr_` to true.  `scale_` was left as `0` since both `scale_(1)` and `scale_(0)` do have the same effect to the code.