### PR TITLE
Regexp operator+ overloads

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1074,7 +1074,12 @@ public:
 		}
 	}
 	friend RegExp operator+(const RegExp& a, const RegExp& b);
-	friend RegExp operator+(const RegExp& e, size_t disp);
+	friend RegExp operator+(const RegExp& e, int disp);
+	friend RegExp operator+(const RegExp& e, unsigned int disp);
+	friend RegExp operator+(const RegExp& e, long disp);
+	friend RegExp operator+(const RegExp& e, unsigned long disp);
+	friend RegExp operator+(const RegExp& e, long long disp);
+	friend RegExp operator+(const RegExp& e, unsigned long long dist);
 	friend RegExp operator-(const RegExp& e, size_t disp);
 private:
 	/*
@@ -1129,12 +1134,40 @@ inline RegExp operator*(int scale, const Reg& r)
 inline RegExp operator+(const RegExp& a, const void* b) { return a + RegExp(b); }
 
 // overload for integer literals (e.g. eax+0) to avoid ambiguity with the void* overload
-inline RegExp operator+(const RegExp& e, int disp) { return e + size_t(disp); }
-
-inline RegExp operator+(const RegExp& e, size_t disp)
+inline RegExp operator+(const RegExp& e, int disp)
 {
 	RegExp ret = e;
-	ret.disp_ += disp;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+inline RegExp operator+(const RegExp& e, unsigned int disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+inline RegExp operator+(const RegExp& e, long disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+inline RegExp operator+(const RegExp& e, unsigned long disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+inline RegExp operator+(const RegExp& e, long long disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
+	return ret;
+}
+inline RegExp operator+(const RegExp& e, unsigned long long disp)
+{
+	RegExp ret = e;
+	ret.disp_ += static_cast<size_t>(disp);
 	return ret;
 }
 


### PR DESCRIPTION
overloads for `RegExp operator+` using:
 -  `unsigned int`
 -  `long`
 - `unsigned long`
 -  `long long`
 - `unsigned long long`
 
This remove the `RegExp operator+` using:
 - `size_t`

This is to avoid ambiguity when other data types such as `unsigned int`, `int64_t` (`long` or `long long`), is used as a displacement (e.g. reg + int64_t_value).

Without these, the compiler saw both the `int` and `size_t` overloads as equally good conversion candidates.

size_t was removed because it is defined differently depending on the OS:
     - `unsigned long long` (Win64/LLP64)
     - `unsigned long` (Linux/macOS/LP64)
     - `unsigned int` (32 bit systems/ILP32)

To keep the `size_t` version would have required OS macros to which was way less clean.

Side note: no additional overloads are needed for `operator-` because there is no pointer (i,e, `const void*`) version of that operator. If an `inline RegExp operator-(const RegExp& a, const void* b)` were added in the future the same overloads would likely need to be added.