### PR TITLE
Add default case for error values.

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -802,6 +802,7 @@ inline void Operand::setBit(int bit)
 		case 256: kind = YMM; break;
 		case 512: kind = ZMM; break;
 		case 8192: kind = TMM; break;
+		default: goto ERR;
 		}
 		idx_ = idx;
 		kind_ = kind;


### PR DESCRIPTION
Even if an error value occurs, the switch statement will not proceed to error handling.