### PR TITLE
fix vcvthf82ph EVEX disp8N tuple type (HALF, not T_N1)

### DIFF
--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -2211,7 +2211,7 @@ void vcvtbiasph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x
 void vcvtbiasph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
 void vcvtbiasph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
 void vcvtdq2ph(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x5B); }
-void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_MUST_EVEX | T_F2 | T_MAP5 | T_W0 | T_YMM | T_N1, 0x1E); }
+void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x1E); }
 void vcvtne2ps2bf16(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_F2|T_0F38|T_W0|T_YMM|T_SAE_Z|T_MUST_EVEX|T_B32, 0x72); }
 void vcvtpd2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5A); }
 void vcvtpd2qq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x7B); }


### PR DESCRIPTION
## Summary

`vcvthf82ph` is currently encoded with `T_N1`, which sets the EVEX
compressed displacement granularity (`disp8N`) to a fixed 1 byte.
This is incorrect.

## Specification

Per the [Intel AVX10.2 Architecture Specification §9.3](https://www.intel.com/content/www/us/en/content-details/836199/intel-advanced-vector-extensions-10-2-intel-avx10-2-architecture-specification.html)
(document 361050-001US, Rev 1.0), `VCVTHF82PH` has tuple type **HALF**.
The memory operand is always half the destination vector width:

| Destination | Memory source | Required disp8N |
|-------------|---------------|-----------------|
| `xmm1` (128-bit) | `m64` | 8 |
| `ymm1` (256-bit) | `m128` | 16 |
| `zmm1` (512-bit) | `m256` | 32 |

The correct xbyak representation is `T_N8|T_N_VL`, which encodes
disp8N = 8 × VL_multiplier (×1/×2/×4 for XMM/YMM/ZMM output).

## Fix

```diff
-void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_MUST_EVEX | T_F2 | T_MAP5 | T_W0 | T_YMM | T_N1, 0x1E); }
+void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x1E); }
```

## Impact

When `vcvthf82ph` is used with a memory operand and the JIT-generated displacement is large enough to use EVEX compressed form, `T_N1` causes the encoded displacement to be interpreted with the wrong scaling factor by the CPU, producing a wrong memory address. This was observed to cause `SIGSEGV` crashes in Intel oneDNN f8_e4m3 kernels (conv, matmul, brgemm) running under SDE ISA emulation. 