### PR TITLE
xbyak_util: guard Win32 CpuTopology against older WinSDK versions

### DIFF
--- a/xbyak/xbyak_util.h
+++ b/xbyak/xbyak_util.h
@@ -1301,7 +1301,53 @@ inline uint32_t popcnt(uint64_t mask)
 #ifdef _WIN32
 
 typedef std::vector<uint32_t> U32Vec;
+
+#if (defined(NTDDI_VERSION) && NTDDI_VERSION >= 0x06010000) || (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0601)
+	#define XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY 1
+#else
+	#define XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY 0
+#endif
+
+#if (defined(NTDDI_VERSION) && NTDDI_VERSION >= 0x0A000000) || (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0A00)
+	#define XBYAK_WINSDK_HAS_EFFICIENCY_CLASS 1
+#else
+	#define XBYAK_WINSDK_HAS_EFFICIENCY_CLASS 0
+#endif
+
+// GroupMasks[] / GroupCount on CACHE_RELATIONSHIP added in Win10 20H1 (SDK 10.0.19041, NTDDI_WIN10_VB)
+// NOTE: _WIN32_WINNT has no sub-version granularity for Win10, so only
+// NTDDI_VERSION can distinguish 20H1 (0x0A00000C) from earlier Win10 builds.
+// If NTDDI_VERSION is not set, this macro will be 0 (safe/conservative fallback).
+#if defined(NTDDI_VERSION) && NTDDI_VERSION >= 0x0A00000C
+	#define XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS 1
+#else
+	#define XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS 0
+#endif
+
+#if XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY
 typedef SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ProcInfo;
+
+// Fallback P/E-core detection via CPUID leaf 0x1A (Intel Hybrid Information).
+// Pins the calling thread to the given GROUP_AFFINITY, reads the core type
+// field from EAX[31:24], then restores the original affinity.
+inline CoreType getCoreTypeViaCpuid(const GROUP_AFFINITY& affinity)
+{
+	// CPUID leaf 0x1A EAX[31:24] core type identifiers (Intel Hybrid Information)
+	const uint32_t Cpuid_StandardCoreType = 0x40; // P-core (Performance)
+	const uint32_t Cpuid_AtomCoreType     = 0x20; // E-core (Efficient)
+
+	GROUP_AFFINITY previousMask = {};
+	if (!SetThreadGroupAffinity(GetCurrentThread(), &affinity, &previousMask)) {
+		return Standard;
+	}
+	uint32_t data[4] = {};
+	Cpu::getCpuidEx(0x1A, 0, data);
+	SetThreadGroupAffinity(GetCurrentThread(), &previousMask, NULL);
+	const uint32_t coreTypeField = (data[0] >> 24) & 0xFF;
+	if (coreTypeField == Cpuid_StandardCoreType) return Performance;
+	if (coreTypeField == Cpuid_AtomCoreType) return Efficient;
+	return Standard;
+}
 
 // return total logical cpus if sucessful, 0 if failed
 inline uint32_t getGroupAcc(U32Vec& v)
@@ -1348,10 +1394,13 @@ static inline uint32_t getCores(std::vector<LogicalCpu>& cpus, bool isHybrid, co
 			cpu.coreId = coreIdx++;
 			if (!isHybrid) {
 				cpu.coreType = Standard;
-			} else if (core.EfficiencyClass > 0) {
-				cpu.coreType = Performance;
 			} else {
-				cpu.coreType = Efficient;
+#if XBYAK_WINSDK_HAS_EFFICIENCY_CLASS
+				cpu.coreType = core.EfficiencyClass > 0 ? Performance : Efficient;
+#else
+				// EfficiencyClass unavailable in this SDK; fall back to CPUID leaf 0x1A
+				cpu.coreType = getCoreTypeViaCpuid(core.GroupMask[0]);
+#endif
 			}
 
 			const GROUP_AFFINITY* masks = core.GroupMask;
@@ -1376,19 +1425,29 @@ static inline uint32_t getCores(std::vector<LogicalCpu>& cpus, bool isHybrid, co
 
 inline bool convertMask(CpuMask& mask, const U32Vec& groupAcc, const CACHE_RELATIONSHIP& cache)
 {
+#if XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS
 	const GROUP_AFFINITY* masks = cache.GroupMasks;
-
 	for (WORD i = 0; i < cache.GroupCount; i++) {
 		const WORD group = masks[i].Group;
 		const KAFFINITY m = masks[i].Mask;
 		const uint32_t base = groupAcc[group];
-
 		for (uint32_t b = 0; b < sizeof(KAFFINITY) * 8; b++) {
 			if (m & (KAFFINITY(1) << b)) {
 				if (!mask.append(base + b)) return false;
 			}
 		}
 	}
+#else
+	// Older SDKs have a single GroupMask field instead of GroupMasks[]
+	const WORD group = cache.GroupMask.Group;
+	const KAFFINITY m = cache.GroupMask.Mask;
+	const uint32_t base = groupAcc[group];
+	for (uint32_t b = 0; b < sizeof(KAFFINITY) * 8; b++) {
+		if (m & (KAFFINITY(1) << b)) {
+			if (!mask.append(base + b)) return false;
+		}
+	}
+#endif
 	return true;
 }
 
@@ -1443,7 +1502,17 @@ inline bool initCpuTopology(CpuTopology& cpuTopo)
 	}
 	return true;
 }
-
+#else
+inline bool initCpuTopology(CpuTopology& cpuTopo)
+{
+	(void)cpuTopo;
+	return false;
+}
+#endif
+// unset WinSDK version macros to avoid Macro pollution
+#undef XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY
+#undef XBYAK_WINSDK_HAS_EFFICIENCY_CLASS
+#undef XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS
 #elif defined(__linux__) // Linux
 
 struct WrapFILE {


### PR DESCRIPTION
## Problem

Building xbyak with a Windows SDK older than Win10 20H1 
(SDK 10.0.19041 / `NTDDI_WIN10_VB`) produces compile errors:

```
xbyak_util.h: error: no member named 'GroupMasks' in '_CACHE_RELATIONSHIP'
xbyak_util.h: error: no member named 'GroupCount' in '_CACHE_RELATIONSHIP'
```

`CACHE_RELATIONSHIP::GroupMasks[]` and `GroupCount` were added to the
Windows SDK in Win10 20H1. Older SDKs expose only a single
`GroupMask` field. Similarly, `PROCESSOR_RELATIONSHIP::EfficiencyClass`
is only available on Win10+ SDKs, and
`SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX` / `GetLogicalProcessorInformationEx`
are only available from Win7 onwards.

This affects any build environment that targets or is pinned to a
pre-20H1 SDK, such as CI runners using the Windows 10 1809 SDK
(`NTDDI_VERSION=0x0A000006`).

---

## Solution

Three SDK-version detection macros are introduced at the top of the
Win32 `CpuTopology` implementation block:

| Macro | Threshold | API gated |
|---|---|---|
| `XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY` | Win7 (`0x0601`) | `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX`, `GetLogicalProcessorInformationEx` |
| `XBYAK_WINSDK_HAS_EFFICIENCY_CLASS` | Win10 (`0x0A00`) | `PROCESSOR_RELATIONSHIP::EfficiencyClass` |
| `XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS` | Win10 20H1 (`0x0A00000C`) | `CACHE_RELATIONSHIP::GroupMasks[]`, `GroupCount` |

The following changes are made:

### 1. Pre-Win7: stub `initCpuTopology`
The entire `SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX`-based implementation
is wrapped in `#if XBYAK_WINSDK_HAS_RELATIONSHIP_GROUP_AFFINITY`. An
`#else` provides a stub that returns `false`, causing `CpuTopology`
construction to throw `ERR_CANT_INIT_CPUTOPOLOGY`. The `Cpu` class
is unaffected as it uses CPUID independently.

### 2. Pre-Win10: CPUID leaf 0x1A fallback for P/E-core detection
`PROCESSOR_RELATIONSHIP::EfficiencyClass` is only available on Win10+
SDKs. Rather than falling back to classifying all cores as `Standard`,
a new `getCoreTypeViaCpuid()` helper is used when
`XBYAK_WINSDK_HAS_EFFICIENCY_CLASS=0`. It temporarily pins the calling
thread to each logical CPU using `SetThreadGroupAffinity` (available
since Win7), executes CPUID leaf `0x1A` (Intel Hybrid Information),
and reads EAX[31:24] to determine the core type (`Cpuid_StandardCoreType`
`0x40` = P-core, `Cpuid_AtomCoreType` `0x20` = E-core). The original affinity
is restored after each query. This mirrors the existing Linux fallback that
uses `sched_setaffinity` + CPUID `0x1A` when `/sys/devices/cpu_core/cpus`
is unavailable. `core.EfficiencyClass` is accessed directly in the Win10+
path.

### 3. Pre-Win10 20H1: single `GroupMask` fallback in `convertMask`
`convertMask()` is updated to use the old single `GroupMask`
(`GROUP_AFFINITY` struct) when `XBYAK_WINSDK_HAS_CACHE_RELATIONSHIP_GROUPMASKS=0`,
instead of iterating `GroupMasks[]`. This is the primary fix for the reported CI build error that was
building using Windows 10 1809 SDK.

---

## Behaviour by SDK target

| SDK target | `HAS_GROUP_AFFINITY` | `HAS_EFFICIENCY_CLASS` | `HAS_GROUPMASKS` | P/E-core detection | Cache mask |
|---|---|---|---|---|---|
| Pre-Win7 (`0x0500`) | 0 | 0 | 0 | `initCpuTopology` returns `false`; `Cpu` class unaffected | n/a |
| Win7–Win8.1 (`0x0601`) | 1 | 0 | 0 | CPUID leaf `0x1A` via `SetThreadGroupAffinity` | `GroupMask` (singular) |
| Win10 pre-20H1 (`0x0A000006`, e.g. 1809) | 1 | 1 | 0 | `EfficiencyClass` from `PROCESSOR_RELATIONSHIP` | `GroupMask` (singular) |
| Win10 20H1+ (`0x0A00000C`) | 1 | 1 | 1 | `EfficiencyClass` from `PROCESSOR_RELATIONSHIP` | `GroupMasks[]` iterated |

---

## Testing

All four code paths were verified by passing explicit `NTDDI_VERSION`
and `_WIN32_WINNT` values as compile definitions to the `cputopology`
sample on a system with SDK 10.0.22000.0:

```powershell
# Path A — pre-Win7 stub
cmake .. -DCMAKE_CXX_FLAGS="/DNTDDI_VERSION=0x05000000 /D_WIN32_WINNT=0x0500"
cmake --build . --target cputopology --config Release
# Expected: "Error: can't init CpuTopology" (exit 1)

# Path B — Win7 era (CPUID 0x1A fallback)
cmake .. -DCMAKE_CXX_FLAGS="/DNTDDI_VERSION=0x06010000 /D_WIN32_WINNT=0x0601"
cmake --build . --target cputopology --config Release
# Expected: builds and runs; correct P/E-core detection via CPUID 0x1A

# Path C — Win10 1809 (reproduces original CI failure)
cmake .. -DCMAKE_CXX_FLAGS="/DNTDDI_VERSION=0x0A000006 /D_WIN32_WINNT=0x0A00"
cmake --build . --target cputopology --config Release
# Expected: builds and runs; correct P/E-core detection via EfficiencyClass

# Path D — Win10 20H1+ (default)
cmake ..
cmake --build . --target cputopology --config Release
# Expected: builds and runs; full topology fidelity
```

All four paths built without errors and produced correct topology
output at runtime. Paths B, C, and D all correctly identified the
hybrid topology on the test system.
