### PR TITLE
Add `T_ALLOW_DIFF_SIZE` to mnemonics that reject ISA-correct address annotations

### DIFF
--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -648,7 +648,7 @@ void jz(std::string label, LabelType type = T_AUTO) { opJmp(label, type, 0x74, 0
 void lahf() { db(0x9F); }
 void lddqu(const Xmm& xmm, const Address& addr) { opSSE(xmm, addr, T_F2 | T_0F, 0xF0); }
 void ldmxcsr(const Address& addr) { opMR(addr, Reg32(2), T_0F, 0xAE); }
-void lea(const Reg& reg, const Address& addr) { if (!reg.isBit(16 | i32e)) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER) opMR(addr, reg, 0, 0x8D); }
+void lea(const Reg& reg, const Address& addr) { if (!reg.isBit(16 | i32e)) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER) opMR(addr, reg, T_ALLOW_DIFF_SIZE, 0x8D); }
 void leave() { db(0xC9); }
 void lfence() { db(0x0F); db(0xAE); db(0xE8); }
 void lfs(const Reg& reg, const Address& addr) { opLoadSeg(addr, reg, T_0F, 0xB4); }

--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -690,7 +690,7 @@ void movbe(const Reg& reg, const Address& addr) { opMR(addr, reg, T_0F38, 0xF0, 
 void movd(const Mmx& mmx, const Operand& op) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F | T_ALLOW_DIFF_SIZE, 0x6E); }
 void movd(const Operand& op, const Mmx& mmx) { if (!(op.isMEM() || op.isREG(32))) XBYAK_THROW(ERR_BAD_COMBINATION) if (mmx.isXMM()) db(0x66); opSSE(mmx, op, T_0F | T_ALLOW_DIFF_SIZE, 0x7E); }
 void movddup(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_DUP|T_F2|T_0F|T_EW1|T_YMM|T_EVEX, 0x12, isXMM_XMMorMEM, NONE); }
-void movdir64b(const Reg& reg, const Address& addr) { opMR(addr, reg.cvt32(), T_66|T_0F38, 0xF8, T_APX|T_66); }
+void movdir64b(const Reg& reg, const Address& addr) { opMR(addr, reg.cvt32(), T_66|T_0F38|T_ALLOW_DIFF_SIZE, 0xF8, T_APX|T_66); }
 void movdiri(const Address& addr, const Reg32e& reg) { opMR(addr, reg, T_0F38, 0xF9, T_APX); }
 void movdq2q(const Mmx& mmx, const Xmm& xmm) { opSSE(mmx, xmm, T_F2 | T_0F, 0xD6); }
 void movdqa(const Address& addr, const Xmm& xmm) { opSSE(xmm, addr, T_0F|T_66, 0x7F); }

--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -156,11 +156,11 @@ void cfcmovz(const Operand& op1, const Operand& op2) { opCfcmov(Reg(), op1, op2,
 void cfcmovz(const Reg& d, const Reg& r, const Operand& op) { opCfcmov(d|T_nf, op, r, 0x44); }
 void clc() { db(0xF8); }
 void cld() { db(0xFC); }
-void cldemote(const Address& addr) { opMR(addr, eax, T_0F, 0x1C); }
-void clflush(const Address& addr) { opMR(addr, Reg32(7), T_0F, 0xAE); }
-void clflushopt(const Address& addr) { opMR(addr, Reg32(7), T_66 | T_0F, 0xAE); }
+void cldemote(const Address& addr) { opMR(addr, eax, T_0F|T_ALLOW_DIFF_SIZE, 0x1C); }
+void clflush(const Address& addr) { opMR(addr, Reg32(7), T_0F|T_ALLOW_DIFF_SIZE, 0xAE); }
+void clflushopt(const Address& addr) { opMR(addr, Reg32(7), T_66|T_0F|T_ALLOW_DIFF_SIZE, 0xAE); }
 void cli() { db(0xFA); }
-void clwb(const Address& addr) { opMR(addr, esi, T_66 | T_0F, 0xAE); }
+void clwb(const Address& addr) { opMR(addr, esi, T_66|T_0F|T_ALLOW_DIFF_SIZE, 0xAE); }
 void clzero() { db(0x0F); db(0x01); db(0xFC); }
 void cmc() { db(0xF5); }
 void cmova(const Reg& d, const Reg& reg, const Operand& op) { opROO(d, op, reg, T_APX|T_ND1, 0x40 | 7); }//-V524
@@ -845,14 +845,14 @@ void pmuludq(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xF4); }
 void popcnt(const Reg&reg, const Operand& op) { opCnt(reg, op, 0xB8); }
 void popf() { db(0x9D); }
 void por(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xEB); }
-void prefetchit0(const Address& addr) { opMR(addr, Reg32(7), T_0F, 0x18); }
-void prefetchit1(const Address& addr) { opMR(addr, Reg32(6), T_0F, 0x18); }
-void prefetchnta(const Address& addr) { opMR(addr, Reg32(0), T_0F, 0x18); }
-void prefetchrst2(const Address& addr) { opMR(addr, Reg32(4), T_0F, 0x18); }
-void prefetcht0(const Address& addr) { opMR(addr, Reg32(1), T_0F, 0x18); }
-void prefetcht1(const Address& addr) { opMR(addr, Reg32(2), T_0F, 0x18); }
-void prefetcht2(const Address& addr) { opMR(addr, Reg32(3), T_0F, 0x18); }
-void prefetchw(const Address& addr) { opMR(addr, Reg32(1), T_0F, 0x0D); }
+void prefetchit0(const Address& addr) { opMR(addr, Reg32(7), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetchit1(const Address& addr) { opMR(addr, Reg32(6), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetchnta(const Address& addr) { opMR(addr, Reg32(0), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetchrst2(const Address& addr) { opMR(addr, Reg32(4), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetcht0(const Address& addr) { opMR(addr, Reg32(1), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetcht1(const Address& addr) { opMR(addr, Reg32(2), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetcht2(const Address& addr) { opMR(addr, Reg32(3), T_0F|T_ALLOW_DIFF_SIZE, 0x18); }
+void prefetchw(const Address& addr) { opMR(addr, Reg32(1), T_0F|T_ALLOW_DIFF_SIZE, 0x0D); }
 void psadbw(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0xF6); }
 void pshufb(const Mmx& mmx, const Operand& op) { opMMX(mmx, op, 0x00, T_0F38, T_66); }
 void pshufd(const Mmx& mmx, const Operand& op, uint8_t imm8) { opMMX(mmx, op, 0x70, T_0F, T_66, imm8); }

--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -372,8 +372,8 @@ void fadd(const Fpu& reg1, const Fpu& reg2) { opFpuFpu(reg1, reg2, 0xD8C0, 0xDCC
 void faddp() { db(0xDE); db(0xC1); }
 void faddp(const Fpu& reg1) { opFpuFpu(reg1, st0, 0x0000, 0xDEC0); }
 void faddp(const Fpu& reg1, const Fpu& reg2) { opFpuFpu(reg1, reg2, 0x0000, 0xDEC0); }
-void fbld(const Address& addr) { opMR(addr, Reg32(4), 0, 0xDF); }
-void fbstp(const Address& addr) { opMR(addr, Reg32(6), 0, 0xDF); }
+void fbld(const Address& addr) { opMR(addr, Reg32(4), T_ALLOW_DIFF_SIZE, 0xDF); }
+void fbstp(const Address& addr) { opMR(addr, Reg32(6), T_ALLOW_DIFF_SIZE, 0xDF); }
 void fchs() { db(0xD9); db(0xE0); }
 void fclex() { db(0x9B); db(0xDB); db(0xE2); }
 void fcmovb(const Fpu& reg1) { opFpuFpu(st0, reg1, 0xDAC0, 0x00C0); }
@@ -435,8 +435,8 @@ void fisubr(const Address& addr) { opFpuMem(addr, 0xDE, 0xDA, 0x00, 5, 0); }
 void fld(const Address& addr) { opFpuMem(addr, 0x00, 0xD9, 0xDD, 0, 0); }
 void fld(const Fpu& reg) { opFpu(reg, 0xD9, 0xC0); }
 void fld1() { db(0xD9); db(0xE8); }
-void fldcw(const Address& addr) { opMR(addr, Reg32(5), 0, 0xD9); }
-void fldenv(const Address& addr) { opMR(addr, Reg32(4), 0, 0xD9); }
+void fldcw(const Address& addr) { opMR(addr, Reg32(5), T_ALLOW_DIFF_SIZE, 0xD9); }
+void fldenv(const Address& addr) { opMR(addr, Reg32(4), T_ALLOW_DIFF_SIZE, 0xD9); }
 void fldl2e() { db(0xD9); db(0xEA); }
 void fldl2t() { db(0xD9); db(0xE9); }
 void fldlg2() { db(0xD9); db(0xEC); }
@@ -452,29 +452,29 @@ void fmulp(const Fpu& reg1, const Fpu& reg2) { opFpuFpu(reg1, reg2, 0x0000, 0xDE
 void fnclex() { db(0xDB); db(0xE2); }
 void fninit() { db(0xDB); db(0xE3); }
 void fnop() { db(0xD9); db(0xD0); }
-void fnsave(const Address& addr) { opMR(addr, Reg32(6), 0, 0xDD); }
-void fnstcw(const Address& addr) { opMR(addr, Reg32(7), 0, 0xD9); }
-void fnstenv(const Address& addr) { opMR(addr, Reg32(6), 0, 0xD9); }
-void fnstsw(const Address& addr) { opMR(addr, Reg32(7), 0, 0xDD); }
+void fnsave(const Address& addr) { opMR(addr, Reg32(6), T_ALLOW_DIFF_SIZE, 0xDD); }
+void fnstcw(const Address& addr) { opMR(addr, Reg32(7), T_ALLOW_DIFF_SIZE, 0xD9); }
+void fnstenv(const Address& addr) { opMR(addr, Reg32(6), T_ALLOW_DIFF_SIZE, 0xD9); }
+void fnstsw(const Address& addr) { opMR(addr, Reg32(7), T_ALLOW_DIFF_SIZE, 0xDD); }
 void fnstsw(const Reg16& r) { if (r.getIdx() != Operand::AX) XBYAK_THROW(ERR_BAD_PARAMETER) db(0xDF); db(0xE0); }
 void fpatan() { db(0xD9); db(0xF3); }
 void fprem() { db(0xD9); db(0xF8); }
 void fprem1() { db(0xD9); db(0xF5); }
 void fptan() { db(0xD9); db(0xF2); }
 void frndint() { db(0xD9); db(0xFC); }
-void frstor(const Address& addr) { opMR(addr, Reg32(4), 0, 0xDD); }
-void fsave(const Address& addr) { db(0x9B); opMR(addr, Reg32(6), 0, 0xDD); }
+void frstor(const Address& addr) { opMR(addr, Reg32(4), T_ALLOW_DIFF_SIZE, 0xDD); }
+void fsave(const Address& addr) { db(0x9B); opMR(addr, Reg32(6), T_ALLOW_DIFF_SIZE, 0xDD); }
 void fscale() { db(0xD9); db(0xFD); }
 void fsin() { db(0xD9); db(0xFE); }
 void fsincos() { db(0xD9); db(0xFB); }
 void fsqrt() { db(0xD9); db(0xFA); }
 void fst(const Address& addr) { opFpuMem(addr, 0x00, 0xD9, 0xDD, 2, 0); }
 void fst(const Fpu& reg) { opFpu(reg, 0xDD, 0xD0); }
-void fstcw(const Address& addr) { db(0x9B); opMR(addr, Reg32(7), 0, 0xD9); }
-void fstenv(const Address& addr) { db(0x9B); opMR(addr, Reg32(6), 0, 0xD9); }
+void fstcw(const Address& addr) { db(0x9B); opMR(addr, Reg32(7), T_ALLOW_DIFF_SIZE, 0xD9); }
+void fstenv(const Address& addr) { db(0x9B); opMR(addr, Reg32(6), T_ALLOW_DIFF_SIZE, 0xD9); }
 void fstp(const Address& addr) { opFpuMem(addr, 0x00, 0xD9, 0xDD, 3, 0); }
 void fstp(const Fpu& reg) { opFpu(reg, 0xDD, 0xD8); }
-void fstsw(const Address& addr) { db(0x9B); opMR(addr, Reg32(7), 0, 0xDD); }
+void fstsw(const Address& addr) { db(0x9B); opMR(addr, Reg32(7), T_ALLOW_DIFF_SIZE, 0xDD); }
 void fstsw(const Reg16& r) { if (r.getIdx() != Operand::AX) XBYAK_THROW(ERR_BAD_PARAMETER) db(0x9B); db(0xDF); db(0xE0); }
 void fsub(const Address& addr) { opFpuMem(addr, 0x00, 0xD8, 0xDC, 4, 0); }
 void fsub(const Fpu& reg1) { opFpuFpu(st0, reg1, 0xD8E0, 0xDCE8); }
@@ -502,7 +502,7 @@ void fwait() { db(0x9B); }
 void fxam() { db(0xD9); db(0xE5); }
 void fxch() { db(0xD9); db(0xC9); }
 void fxch(const Fpu& reg) { opFpu(reg, 0xD9, 0xC8); }
-void fxrstor(const Address& addr) { opMR(addr, Reg32(1), T_0F, 0xAE); }
+void fxrstor(const Address& addr) { opMR(addr, Reg32(1), T_0F|T_ALLOW_DIFF_SIZE, 0xAE); }
 void fxtract() { db(0xD9); db(0xF4); }
 void fyl2x() { db(0xD9); db(0xF1); }
 void fyl2xp1() { db(0xD9); db(0xF9); }
@@ -1875,7 +1875,7 @@ void stui() { db(0xF3); db(0x0F); db(0x01); db(0xEF); }
 void testui() { db(0xF3); db(0x0F); db(0x01); db(0xED); }
 void uiret() { db(0xF3); db(0x0F); db(0x01); db(0xEC); }
 void cmpxchg16b(const Address& addr) { opMR(addr, Reg64(1), T_0F|T_ALLOW_DIFF_SIZE, 0xC7); }
-void fxrstor64(const Address& addr) { opMR(addr, Reg64(1), T_0F, 0xAE); }
+void fxrstor64(const Address& addr) { opMR(addr, Reg64(1), T_0F|T_ALLOW_DIFF_SIZE, 0xAE); }
 void movq(const Reg64& reg, const Mmx& mmx) { if (mmx.isXMM()) db(0x66); opSSE(mmx, reg, T_0F, 0x7E); }
 void movq(const Mmx& mmx, const Reg64& reg) { if (mmx.isXMM()) db(0x66); opSSE(mmx, reg, T_0F, 0x6E); }
 void movrs(const Reg& reg, const Address& addr) { opMR(addr, reg, T_0F38, reg.isBit(8) ? 0x8A : 0x8B); }

--- a/xbyak/xbyak_mnemonic.h
+++ b/xbyak/xbyak_mnemonic.h
@@ -265,7 +265,7 @@ void cmpunordps(const Xmm& x, const Operand& op) { cmpps(x, op, 3); }
 void cmpunordsd(const Xmm& x, const Operand& op) { cmpsd(x, op, 3); }
 void cmpunordss(const Xmm& x, const Operand& op) { cmpss(x, op, 3); }
 void cmpxchg(const Operand& op, const Reg& reg) { opRO(reg, op, T_0F, 0xB0 | (reg.isBit(8) ? 0 : 1), op.getBit() == reg.getBit()); }
-void cmpxchg8b(const Address& addr) { opMR(addr, Reg32(1), T_0F, 0xC7); }
+void cmpxchg8b(const Address& addr) { opMR(addr, Reg32(1), T_0F|T_ALLOW_DIFF_SIZE, 0xC7); }
 void comisd(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_66|T_0F, 0x2F, isXMM_XMMorMEM); }
 void comiss(const Xmm& xmm, const Operand& op) { opSSE(xmm, op, T_0F, 0x2F, isXMM_XMMorMEM); }
 void cpuid() { db(0x0F); db(0xA2); }


### PR DESCRIPTION
Related issue: https://github.com/herumi/xbyak/issues/253

## Summary

When `XBYAK_STRICT_CHECK_MEM_REG_SIZE=1` is enabled, a number of instructions
in `xbyak_mnemonic.h` throw a false-positive `ERR_BAD_MEM_SIZE` when the
caller annotates the address operand in the way the Intel ISA manual documents.
The root cause and full list of affected instructions are described in issue
#253. This PR applies the fix.

Each commit is self-contained and addresses a distinct set of instructions, so
any commit can be dropped individually if the maintainer disagrees with the
rationale for that group.

## Commits

### 1. Allow mismatched size for prefetch/cache mnemonics

`prefetcht0/1/2`, `prefetchnta`, `prefetchw`, `prefetchrst2`, `prefetchit0/1`,
`clflush`, `clflushopt`, `clwb`, `cldemote`.

All use a synthetic `Reg32(N)` or named 32-bit register (`eax`, `esi`) as a
ModRM `/N` opcode-group selector. The Intel ISA manual operand is `m8`. A
caller writing `prefetcht0(byte[ptr])` gets `ERR_BAD_MEM_SIZE` because
8 != 32.

### 2. Allow mismatched size for `movdir64b`

`movdir64b` reads `m512` from memory but passes `reg.cvt32()` to `opMR()` as
a ModRM encoding artifact. The 32-bit internal register triggers
`ERR_BAD_MEM_SIZE` when the source is annotated `zword[addr]` (512-bit).

### 3. Allow mismatched size for `lea`

`LEA` computes an effective address and never accesses memory. The Intel ISA
manual gives no size for its memory operand (`m`). A caller writing
`lea(reg64, zword[base + offset])` gets `ERR_BAD_MEM_SIZE` because
512 != 64.

### 4. Allow mismatched size for `cmpxchg8b`

`cmpxchg8b` accesses `m64` but uses `Reg32(1)` as a ModRM `/1` encoding
artifact, mirroring the existing pattern of `cmpxchg16b` which already carries
`T_ALLOW_DIFF_SIZE`. A caller writing `cmpxchg8b(qword[ptr])` gets
`ERR_BAD_MEM_SIZE` because 64 != 32.

### 5. Allow mismatched size for x87 FP state mnemonics

`fbld`, `fbstp`, `fldcw`, `fldenv`, `fnsave`, `fnstcw`, `fnstenv`, `fnstsw`,
`frstor`, `fsave`, `fstcw`, `fstenv`, `fstsw`, `fxrstor`, `fxrstor64`.

All use `Reg32(N)` as a ModRM `/N` selector, but their ISA-specified memory
operands are not 32 bits (`m16`, `m80`, `m14/28byte`, `m94/108byte`,
`m512byte`). A caller annotating the address to match the Intel manual triggers
`ERR_BAD_MEM_SIZE`.

## No change to emitted machine code

`T_ALLOW_DIFF_SIZE` only suppresses the strict-check assertion. It has no
effect on instruction encoding.
