### PR TITLE
xbyak: util: fix declared Tmm type

### DIFF
--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -930,6 +930,27 @@ CYBOZU_TEST_AUTO(AMX)
 	CYBOZU_TEST_EQUAL_ARRAY(c.getCode(), tbl, n);
 }
 
+// Regression test: Xbyak::util::tmm0-tmm7 were once declared as type Zmm
+// instead of Tmm in xbyak.h's `namespace util` block, while CodeGenerator's
+// own tmm0-tmm7 members (what every unqualified "tmmN" call in the tests
+// above actually resolves to) were always correctly typed Tmm. The mistake
+// was invisible under the normal CodeGenerator-inheritance style: inside a
+// CodeGenerator member function, unqualified "tmmN" always binds to the
+// class's own member first and never reaches the namespace copy.
+CYBOZU_TEST_AUTO(util_tmm)
+{
+	const uint8_t b[] = {
+		0xC4, 0xE2, 0x7B, 0x49, 0xD0,  // TILEZERO TMM2
+	};
+	const size_t n = sizeof(b) / sizeof(b[0]);
+
+	Xbyak::CodeGenerator code;
+	code.tilezero(Xbyak::util::tmm2);
+
+	CYBOZU_TEST_EQUAL(code.getSize(), n);
+	CYBOZU_TEST_EQUAL_ARRAY(code.getCode(), b, n);
+}
+
 CYBOZU_TEST_AUTO(tileloadd)
 {
 	struct Code : Xbyak::CodeGenerator {

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -3513,7 +3513,7 @@ static const XBYAK_CONSTEXPR Ymm ymm24(24), ymm25(25), ymm26(26), ymm27(27), ymm
 static const XBYAK_CONSTEXPR Zmm zmm8(8), zmm9(9), zmm10(10), zmm11(11), zmm12(12), zmm13(13), zmm14(14), zmm15(15);
 static const XBYAK_CONSTEXPR Zmm zmm16(16), zmm17(17), zmm18(18), zmm19(19), zmm20(20), zmm21(21), zmm22(22), zmm23(23);
 static const XBYAK_CONSTEXPR Zmm zmm24(24), zmm25(25), zmm26(26), zmm27(27), zmm28(28), zmm29(29), zmm30(30), zmm31(31);
-static const XBYAK_CONSTEXPR Zmm tmm0(0), tmm1(1), tmm2(2), tmm3(3), tmm4(4), tmm5(5), tmm6(6), tmm7(7);
+static const XBYAK_CONSTEXPR Tmm tmm0(0), tmm1(1), tmm2(2), tmm3(3), tmm4(4), tmm5(5), tmm6(6), tmm7(7);
 static const XBYAK_CONSTEXPR RegRip rip;
 static const XBYAK_CONSTEXPR ApxFlagNF T_nf;
 static const XBYAK_CONSTEXPR ApxFlagZU T_zu;


### PR DESCRIPTION
Incorrectly declared as `Zmm` before. The errant declaration manifests as a compiler error when the xbyak::util::tmmX constants are used explicitly. In the inheritance style, the member, not the namespace, constant is used, concealing the issue.

Fix the declaration, and add a regression test.

If you attempt to compile the patched `misc.cpp` *before* patching `xbyak.h`, you should see a compiler error like:
```
% make misc
g++ -O2 -Wall -I.. -I. -Wall -Wextra -Wsuggest-override -Wformat=2 -Wcast-qual -Wwrite-strings -Wfloat-equal -Wpointer-arith     misc.cpp -o misc
misc.cpp: In function ‘void cybozu_test_util_tmm()’:
misc.cpp:948:36: error: cannot convert ‘const Xbyak::Zmm’ to ‘const Xbyak::Tmm&’
  948 |         code.tilezero(Xbyak::util::tmm2);
      |                       ~~~~~~~~~~~~~^~~~
      |                                    |
      |                                    const Xbyak::Zmm
In file included from ../xbyak/xbyak.h:3458,
                 from misc.cpp:4:
../xbyak/xbyak_mnemonic.h:1948:26: note: initializing argument 1 of ‘void Xbyak::CodeGenerator::tilezero(const Xbyak::Tmm&)’
 1948 | void tilezero(const Tmm& t) { opVex(t, &tmm0, tmm0, T_F2|T_0F38|T_W0, 0x49); }
      |               ~~~~~~~~~~~^
make: *** [Makefile:54: misc] Error 1
```

PS:
```
% g++ --version
g++ (GCC) 16.1.1 20260625
```