### PR TITLE
xbyak: add ptr[seg:reg] syntax; fix putSeg() segment prefix bytes

### DIFF
--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -2471,4 +2471,42 @@ CYBOZU_TEST_AUTO(vmovw)
 	CYBOZU_TEST_EQUAL_ARRAY(c.getCode(), tbl, n);
 }
 
+CYBOZU_TEST_AUTO(segment)
+{
+	struct Code : Xbyak::CodeGenerator {
+		Code()
+		{
+			mov(eax, ptr[es + rax]);
+			mov(eax, ptr[cs + rax]);
+			mov(eax, ptr[ss + rax]);
+			mov(eax, ptr[ds + rax]);
+			mov(eax, ptr[fs + rax]);
+			mov(eax, ptr[gs + rax]);
+			vmovdqu(ymm0, ptr[fs + rax + rbx * 4]);
+			vmovdqu32(zm0 | k1, ptr[gs + rax]);
+			putSeg(es); mov(eax, ptr[eax]);
+			putSeg(cs); mov(eax, ptr[eax]);
+			putSeg(ss); mov(eax, ptr[eax]);
+			putSeg(ds); mov(eax, ptr[eax]);
+		}
+	} c;
+	const uint8_t tbl[] = {
+		0x26, 0x8B, 0x00, // mov(eax, ptr[es+rax])
+		0x2E, 0x8B, 0x00, // mov(eax, ptr[cs+rax])
+		0x36, 0x8B, 0x00, // mov(eax, ptr[ss+rax])
+		0x3E, 0x8B, 0x00, // mov(eax, ptr[ds+rax])
+		0x64, 0x8B, 0x00, // mov(eax, ptr[fs+rax])
+		0x65, 0x8B, 0x00, // mov(eax, ptr[gs+rax])
+		0x64, 0xC5, 0xFE, 0x6F, 0x04, 0x98, // vmovdqu(ymm0, ptr[fs+rax+rbx*4])
+		0x65, 0x62, 0xF1, 0x7E, 0x49, 0x6F, 0x00, // vmovdqu32(zm0|k1, ptr[gs+rax])
+		0x26, 0x67, 0x8B, 0x00, // putSeg(es); mov(eax, ptr[eax])
+		0x2E, 0x67, 0x8B, 0x00, // putSeg(cs); mov(eax, ptr[eax])
+		0x36, 0x67, 0x8B, 0x00, // putSeg(ss); mov(eax, ptr[eax])
+		0x3E, 0x67, 0x8B, 0x00, // putSeg(ds); mov(eax, ptr[eax])
+	};
+	const size_t n = sizeof(tbl) / sizeof(tbl[0]);
+	CYBOZU_TEST_EQUAL(c.getSize(), n);
+	CYBOZU_TEST_EQUAL_ARRAY(c.getCode(), tbl, n);
+}
+
 #endif

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1063,7 +1063,7 @@ public:
 	}
 	bool operator==(const RegExp& rhs) const
 	{
-		return base_ == rhs.base_ && index_ == rhs.index_ && disp_ == rhs.disp_ && scale_ == rhs.scale_;
+		return base_ == rhs.base_ && index_ == rhs.index_ && disp_ == rhs.disp_ && scale_ == rhs.scale_ && seg_ == rhs.seg_;
 	}
 	const Reg& getBase() const { return base_; }
 	const Reg& getIndex() const { return index_; }
@@ -1071,6 +1071,8 @@ public:
 	bool isOnlyDisp() const { return !base_.getBit() && !index_.getBit(); } // for mov eax
 	int getScale() const { return scale_; }
 	size_t getDisp() const { return disp_; }
+	bool hasSeg() const { return seg_ >= 0; }
+	int getSeg() const { return seg_; }
 	XBYAK_CONSTEXPR void verify() const
 	{
 		if (base_.getBit() >= 128) XBYAK_THROW(ERR_BAD_SIZE_OF_REGISTER)
@@ -1082,6 +1084,9 @@ public:
 	friend RegExp operator+(const RegExp& a, const RegExp& b);
 	friend RegExp operator+(const RegExp& e, unsigned long long disp);
 	friend RegExp operator-(const RegExp& e, size_t disp);
+#ifndef XBYAK_DISABLE_SEGMENT
+	friend RegExp operator+(const Segment& seg, const RegExp& e);
+#endif
 private:
 	/*
 		[base_ + index_ * scale_ + disp_]
@@ -1094,6 +1099,7 @@ private:
 	Label *label_;
 	bool rip_;
 	bool asPtr_; // disp_ contains a pointer
+	int seg_ = -1; // Segment::(es|cs|...), -1 = none
 };
 
 inline RegExp operator+(const RegExp& a, const RegExp& b)
@@ -1103,7 +1109,9 @@ inline RegExp operator+(const RegExp& a, const RegExp& b)
 	if (b.rip_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
 	if (a.rip_ && !b.isOnlyDisp()) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
 	if (a.asPtr_ && b.asPtr_) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	if (a.seg_ >= 0 && b.seg_ >= 0) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
 	RegExp ret = a;
+	if (ret.seg_ < 0) ret.seg_ = b.seg_;
 	if (ret.label_ == 0) ret.label_ = b.label_;
 	if (ret.asPtr_ == 0) ret.asPtr_ = b.asPtr_;
 	if (!ret.index_.getBit()) { ret.index_ = b.index_; ret.scale_ = b.scale_; }
@@ -1122,6 +1130,15 @@ inline RegExp operator+(const RegExp& a, const RegExp& b)
 	ret.disp_ += b.disp_;
 	return ret;
 }
+#ifndef XBYAK_DISABLE_SEGMENT
+inline RegExp operator+(const Segment& seg, const RegExp& e)
+{
+	if (e.seg_ >= 0) XBYAK_THROW_RET(ERR_BAD_ADDRESSING, RegExp())
+	RegExp ret = e;
+	ret.seg_ = seg.getIdx();
+	return ret;
+}
+#endif
 inline RegExp operator*(const Reg& r, int scale)
 {
 	return RegExp(r, scale);
@@ -1436,6 +1453,8 @@ public:
 	}
 	bool operator!=(const Address& rhs) const { return !operator==(rhs); }
 	bool isVsib() const { return e_.isVsib(); }
+	bool hasSeg() const { return e_.hasSeg(); }
+	int getSeg() const { return e_.getSeg(); }
 	// change byte to dword etc.
 	Address changeBit(int bit) const { Address addr(*this); addr.setBit(bit); return addr; }
 private:
@@ -1891,6 +1910,9 @@ private:
 		const Operand *p1 = &op1, *p2 = &op2;
 		if (p1->isMEM()) std::swap(p1, p2);
 		if (p1->isMEM()) XBYAK_THROW_RET(ERR_BAD_COMBINATION, false)
+#ifndef XBYAK_DISABLE_SEGMENT
+		if (p2->isMEM() && p2->getAddress().hasSeg()) putSeg(Segment(p2->getAddress().getSeg()));
+#endif
 		// except movsx(16bit, 32/64bit)
 		bool p66 = (op1.isBit(16) && !op2.isBit(i32e)) || (op2.isBit(16) && !op1.isBit(i32e));
 		if ((type & T_66) || p66) db(0x66);
@@ -2616,6 +2638,9 @@ private:
 			const RegExp& regExp = addr.getRegExp();
 			const Reg& base = regExp.getBase();
 			const Reg& index = regExp.getIndex();
+#ifndef XBYAK_DISABLE_SEGMENT
+			if (addr.hasSeg()) putSeg(Segment(addr.getSeg()));
+#endif
 			if (BIT == 64 && addr.is32bit()) db(0x67);
 			int disp8N = 0;
 			if ((type & (T_MUST_EVEX|T_MEM_EVEX)) || r.hasEvex() || (p1 && p1->hasEvex()) || addr.isBroadcast() || addr.getOpmaskIdx() || addr.hasRex2()) {
@@ -3244,10 +3269,10 @@ public:
 	void putSeg(const Segment& seg)
 	{
 		switch (seg.getIdx()) {
-		case Segment::es: db(0x2E); break;
-		case Segment::cs: db(0x36); break;
-		case Segment::ss: db(0x3E); break;
-		case Segment::ds: db(0x26); break;
+		case Segment::es: db(0x26); break;
+		case Segment::cs: db(0x2E); break;
+		case Segment::ss: db(0x36); break;
+		case Segment::ds: db(0x3E); break;
 		case Segment::fs: db(0x64); break;
 		case Segment::gs: db(0x65); break;
 		default:


### PR DESCRIPTION
putSeg() emitted wrong bytes for es/cs/ss/ds (each shifted to the next segment's byte). fs/gs were fine, so no test caught this.

es=26H, cs=2EH, ss=36H, ds=3EH. Now fixed.

Also add direct segment-override syntax on memory operands, e.g.:
  mov(eax, ptr[fs + rax]);
instead of the old two-step
  putSeg(fs); mov(eax, ptr[rax]);

Works for legacy, VEX, and EVEX (segment byte always emitted first). Added test/misc.cpp:segment for both.

See: Intel SDM Vol. 2, Sec 2.1.1
See: https://cdrdv2.intel.com/v1/dl/getContent/671110