### PR TITLE
CodeGenerator: opVmov: throw error for {z} with memory operand

### DIFF
--- a/test/misc.cpp
+++ b/test/misc.cpp
@@ -272,6 +272,24 @@ CYBOZU_TEST_AUTO(kmask)
 	} c;
 }
 
+// {z} (zeroing-masking) has no architectural meaning when the destination of a
+// downconvert store-form instruction (dispatched via opVmov) is memory; only
+// merge-masking ({k} without {z}) is valid there.
+CYBOZU_TEST_AUTO(vpmov_store_zero)
+{
+	struct Code : Xbyak::CodeGenerator {
+		Code()
+		{
+			// mode=false family (narrow dest is byte-sized relative to source)
+			CYBOZU_TEST_NO_EXCEPTION(vpmovdb(ptr[eax], xmm3|k4));
+			CYBOZU_TEST_EXCEPTION(vpmovdb(ptr[eax], xmm3|k4|T_z), std::exception);
+			// mode=true family (narrow dest is word/dword-sized relative to source)
+			CYBOZU_TEST_NO_EXCEPTION(vpmovqd(ptr[eax], xmm3|k4));
+			CYBOZU_TEST_EXCEPTION(vpmovqd(ptr[eax], xmm3|k4|T_z), std::exception);
+		}
+	} c;
+}
+
 CYBOZU_TEST_AUTO(gather)
 {
 	struct Code : Xbyak::CodeGenerator {

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -2809,6 +2809,8 @@ private:
 		} else {
 			if (!op.isMEM() && !op.isXMM()) XBYAK_THROW(ERR_BAD_COMBINATION)
 		}
+		// zeroing-masking has no meaning when the destination is memory
+		if (op.isMEM() && (op.hasZero() || x.hasZero())) XBYAK_THROW(ERR_INVALID_ZERO)
 		opVex(x, 0, op, type, code);
 	}
 	void opGatherFetch(const Address& addr, const Xmm& x, uint64_t type, uint8_t code, Operand::Kind kind)


### PR DESCRIPTION
{z} (zeroing) is not valid when the destination is memory. Before this fix, Xbyak could generate bad encodings silently.

Now opVmov() throws Error(ERR_INVALID_ZERO) if {z} is used with a memory operand, like opGather2/opGatherFetch already do.

Add test in test/misc.cpp to check this.