### PR TITLE
AlignedMalloc: round size up to alignment

### DIFF
--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -382,6 +382,11 @@ inline const char *ConvertErrorToString(const Error& err)
 
 inline void *AlignedMalloc(size_t size, size_t alignment)
 {
+	// Round size up to a multiple of alignment. protect()/setProtectMode()
+	// change permissions for the whole [alignment]-sized region starting
+	// at the returned pointer, so we must not let the underlying allocator
+	// place anything else of ours in the same region.
+	size = (size + alignment - 1) & ~(alignment - 1);
 #ifdef __MINGW32__
 	return __mingw_aligned_malloc(size, alignment);
 #elif defined(_WIN32)


### PR DESCRIPTION
CodeArray's default Allocator gets its buffer from AlignedMalloc(size, getPageSize()), then later calls protect()/setProtectMode() on that pointer for `size` bytes -- but VirtualProtect()/mprotect() operate at page granularity, so the actual region affected is the whole page(s) containing [ptr, ptr+size), not just the `size` bytes requested.

AlignedMalloc only promises that the returned pointer is aligned; it does not promise that the caller owns the whole aligned region. Most heap allocators are happy to place unrelated data in whatever space is left over past the end of a small allocation, even one requested with a large alignment. Example: `CodeGenerator gen(256, Xbyak::AutoGrow);` followed by `gen.readyRE();` asks for a 256-byte buffer aligned to a 4096-byte page, then changes protection on that buffer to read+exec. If the allocator placed unrelated heap data (e.g. another allocation, or the heap's own free-list bookkeeping) in the remaining ~3840 bytes of that same page, that data silently loses its write permission too. Any later write to it (e.g. a subsequent unrelated allocation needing to update heap metadata sharing the page) faults.

This was found on Windows: `__mingw_aligned_malloc(256, 4096)` returned a pointer whose containing page was shared with other heap data; VirtualProtect() on the 256-byte region changed protection for the entire page, and a subsequent, unrelated heap write into that same page crashed with an access violation.

It likely goes unnoticed on Linux/glibc because posix_memalign(), when given an alignment much larger than the requested size, tends to carve the aligned block out of a larger backing chunk; whether the leftover tail chunk is left available for reuse by later allocations depends on implementation details (minimum chunk size, arena state) that make the sharing observed on Windows less likely, but this is a property of a given allocator's heuristics, not a guarantee.

Round `size` up to a multiple of `alignment` before allocating, so the allocator is asked for the entire aligned granule instead of a small fraction of it, making it unlikely for it to place anything else there.