### PR TITLE
CodeArray: fix SEGV-on-alloc edge case

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -90,6 +90,7 @@ endif
 	./misc.exe
 	./misc32.exe
 	./cvt_test.exe
+	./noexception.exe
 ifeq ($(BIT),64)
 	CXX=$(CXX) ./test_address.sh 64
 ifneq ($(X32),1)

--- a/test/noexception.cpp
+++ b/test/noexception.cpp
@@ -61,8 +61,12 @@ void test3()
 	struct Code : CodeGenerator {
 		Code() : CodeGenerator(8, 0, &emptyAllocator)
 		{
-			mov(eax, 3);
+			assertBool(Xbyak::GetError() != 0);
+			Xbyak::ClearError();
 			assertBool(Xbyak::GetError() == 0);
+			mov(eax, 3);
+			assertBool(Xbyak::GetError() != 0);
+			Xbyak::ClearError();
 			mov(eax, 3);
 			mov(eax, 3);
 			assertBool(Xbyak::GetError() != 0);

--- a/xbyak/xbyak.h
+++ b/xbyak/xbyak.h
@@ -1286,6 +1286,7 @@ public:
 				XBYAK_THROW(ERR_CODE_IS_TOO_BIG)
 			}
 		}
+		if (top_ == 0) XBYAK_THROW(ERR_CANT_ALLOC)
 		top_[size_++] = static_cast<uint8_t>(code);
 	}
 	void db(const uint8_t *code, size_t codeSize)


### PR DESCRIPTION
```
    CodeArray: fix segv on alloc with XBYAK_NO_EXCEPTION
    
    CodeArray::db() wrote to top_ without checking it, so a failed
    allocation (e.g. custom Allocator::alloc() returns 0) caused a
    null pointer write on the first emitted byte.
    
    - xbyak.h: check top_ == 0 in db() and throw ERR_CANT_ALLOC instead
    - test/noexception.cpp: fix test3() asserts to match real behavior
    - test/Makefile: run noexception.exe in test_nm (it was built but
      never run, so this bug was never caught)
```

PS: I operate in a 64-bit Linux environment